### PR TITLE
6741 - Adding device info to about page

### DIFF
--- a/src/webview/java/org/medicmobile/webapp/mobile/MedicAndroidJavascript.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/MedicAndroidJavascript.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.app.ActivityManager.MemoryInfo;
 import android.app.DatePickerDialog;
+import android.content.pm.PackageInfo;
 import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
@@ -223,11 +224,15 @@ public class MedicAndroidJavascript {
 				return jsonError("ConnectivityManager not set. Cannot retrieve network info.");
 			}
 
-			String versionName = parent.getPackageManager()
-					.getPackageInfo(parent.getPackageName(), 0)
-					.versionName;
+			PackageInfo packageInfo = parent
+					.getPackageManager()
+					.getPackageInfo(parent.getPackageName(), 0);
+			long versionCode = Build.VERSION.SDK_INT < Build.VERSION_CODES.P ? (long)packageInfo.versionCode : packageInfo.getLongVersionCode();
+
 			JSONObject appObject = new JSONObject();
-			appObject.put("version", versionName);
+			appObject.put("version", packageInfo.versionName);
+			appObject.put("packageName", packageInfo.packageName);
+			appObject.put("versionCode", versionCode);
 
 			String androidVersion = Build.VERSION.RELEASE;
 			int osApiLevel = Build.VERSION.SDK_INT;

--- a/src/xwalk/java/org/medicmobile/webapp/mobile/MedicAndroidJavascript.java
+++ b/src/xwalk/java/org/medicmobile/webapp/mobile/MedicAndroidJavascript.java
@@ -3,6 +3,7 @@ package org.medicmobile.webapp.mobile;
 import android.app.ActivityManager;
 import android.app.ActivityManager.MemoryInfo;
 import android.app.DatePickerDialog;
+import android.content.pm.PackageInfo;
 import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
@@ -235,11 +236,15 @@ public class MedicAndroidJavascript {
 				return jsonError("ConnectivityManager not set. Cannot retrieve network info.");
 			}
 
-			String versionName = parent.getPackageManager()
-					.getPackageInfo(parent.getPackageName(), 0)
-					.versionName;
+			PackageInfo packageInfo = parent
+					.getPackageManager()
+					.getPackageInfo(parent.getPackageName(), 0);
+			long versionCode = Build.VERSION.SDK_INT < Build.VERSION_CODES.P ? (long)packageInfo.versionCode : packageInfo.getLongVersionCode();
+
 			JSONObject appObject = new JSONObject();
-			appObject.put("version", versionName);
+			appObject.put("version", packageInfo.versionName);
+			appObject.put("packageName", packageInfo.packageName);
+			appObject.put("versionCode", versionCode);
 
 			String androidVersion = Build.VERSION.RELEASE;
 			int osApiLevel = Build.VERSION.SDK_INT;


### PR DESCRIPTION
# Description

Adding more info to getDeviceInfo method that will be used in about page: packageName and versionCode.

Telemetry is already saving this data [here](https://github.com/medic/cht-core/blob/28f2afb6bf5870ba73aabf8f8f20b237a05648ab/webapp/src/ts/services/telemetry.service.ts#L161).

CHT-Core: https://github.com/medic/cht-core/pull/7131
CHT-Docs: https://github.com/medic/cht-docs/pull/514

https://github.com/medic/cht-core/issues/6741

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.