### PR TITLE
164 - Meet new Google Play's target API level (SDK 30) and packaging requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         options: '{ "flavor": "unbranded" }'
 
   instrumentation-tests:
+    name: Instrumentation tests
     runs-on: macos-latest
     steps:
     - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,16 @@
 name: Build and test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+    tags-ignore:
+      - *
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+    tags-ignore:
+      - *
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - 'README.md'
     tags-ignore:
-      - *
+      - v*.*.*
   pull_request:
     paths-ignore:
       - 'README.md'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,11 +41,11 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "medicmobilegamma" }'
-    - name: Assemble demo
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "medicmobiledemo" }'
+#    - name: Assemble demo
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "medicmobiledemo" }'
     - name: Assemble bracuganda
       uses: maierj/fastlane-action@v1.4.0
       with:
@@ -166,11 +166,11 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "trippleeighty" }'
-    - name: Assemble unbranded_test
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "unbranded_test" }'
+#    - name: Assemble unbranded_test
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "unbranded_test" }'
     - name: Assemble vhw_burundi
       uses: maierj/fastlane-action@v1.4.0
       with:
@@ -201,8 +201,11 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true
+        # APKs for webview-armeabi-v7a are not uploaded
         files: |
-          build/outputs/apk/**/*.apk
+          build/outputs/apk/**/*-xwalk-arm64-v8a-release.apk
+          build/outputs/apk/**/*-xwalk-armeabi-v7a-release.apk
+          build/outputs/apk/**/*-webview-arm64-v8a-release.apk
           build/outputs/bundle/**/*.aab
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,6 +201,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true
-        files: build/outputs/apk/**/*.apk
+        files: |
+          build/outputs/apk/**/*.apk
+          build/outputs/bundle/**/*.aab
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,161 +41,161 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "medicmobilegamma" }'
-#    - name: Assemble demo
+    - name: Assemble demo
+      uses: maierj/fastlane-action@v1.4.0
+      with:
+        lane: build
+        options: '{ "flavor": "medicmobiledemo" }'
+#    - name: Assemble bracuganda
 #      uses: maierj/fastlane-action@v1.4.0
 #      with:
 #        lane: build
-#        options: '{ "flavor": "medicmobiledemo" }'
-    - name: Assemble bracuganda
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "bracuganda" }'
-    - name: Assemble cic_guatemala
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "cic_guatemala" }'
-    - name: Assemble cmmb_kenya
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "cmmb_kenya" }'
-    - name: Assemble covid_moh_mali
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "covid_moh_mali" }'
-    - name: Assemble ebpp_indonesia
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "ebpp_indonesia" }'
-    - name: Assemble hope_through_health
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "hope_through_health" }'
-    - name: Assemble livinggoods
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "livinggoods" }'
-    - name: Assemble livinggoodskenya
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "livinggoodskenya" }'
-    - name: Assemble livinggoods_assisted_networks
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "livinggoods_assisted_networks" }'
-    - name: Assemble livinggoods_innovation_ke_supervisor
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "livinggoods_innovation_ke_supervisor" }'
-    - name: Assemble livinggoods_innovation_ke_hivst
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "livinggoods_innovation_ke_hivst" }'
-    - name: Assemble moh_kenya_siaya_red
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "moh_kenya_siaya_red" }'
-    - name: Assemble moh_kenya_siaya_green
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "moh_kenya_siaya_green" }'
-    - name: Assemble moh_kenya_siaya_black
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "moh_kenya_siaya_black" }'
-    - name: Assemble moh_mali
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "moh_mali" }'
-    - name: Assemble moh_zanzibar_training
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "moh_zanzibar_training" }'
-    - name: Assemble moh_zanzibar
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "moh_zanzibar" }'
-    - name: Assemble musomali
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "musomali" }'
-    - name: Assemble pih_malawi
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "pih_malawi" }'
-    - name: Assemble pih_malawi_supervisor
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "pih_malawi_supervisor" }'
-    - name: Assemble safaridoctors_kenya
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "safaridoctors_kenya" }'
-    - name: Assemble simprints
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "simprints" }'
-    - name: Assemble surveillance_covid19_kenya
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "surveillance_covid19_kenya" }'
-    - name: Assemble trippleeighty
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "trippleeighty" }'
+#        options: '{ "flavor": "bracuganda" }'
+#    - name: Assemble cic_guatemala
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "cic_guatemala" }'
+#    - name: Assemble cmmb_kenya
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "cmmb_kenya" }'
+#    - name: Assemble covid_moh_mali
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "covid_moh_mali" }'
+#    - name: Assemble ebpp_indonesia
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "ebpp_indonesia" }'
+#    - name: Assemble hope_through_health
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "hope_through_health" }'
+#    - name: Assemble livinggoods
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "livinggoods" }'
+#    - name: Assemble livinggoodskenya
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "livinggoodskenya" }'
+#    - name: Assemble livinggoods_assisted_networks
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "livinggoods_assisted_networks" }'
+#    - name: Assemble livinggoods_innovation_ke_supervisor
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "livinggoods_innovation_ke_supervisor" }'
+#    - name: Assemble livinggoods_innovation_ke_hivst
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "livinggoods_innovation_ke_hivst" }'
+#    - name: Assemble moh_kenya_siaya_red
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "moh_kenya_siaya_red" }'
+#    - name: Assemble moh_kenya_siaya_green
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "moh_kenya_siaya_green" }'
+#    - name: Assemble moh_kenya_siaya_black
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "moh_kenya_siaya_black" }'
+#    - name: Assemble moh_mali
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "moh_mali" }'
+#    - name: Assemble moh_zanzibar_training
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "moh_zanzibar_training" }'
+#    - name: Assemble moh_zanzibar
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "moh_zanzibar" }'
+#    - name: Assemble musomali
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "musomali" }'
+#    - name: Assemble pih_malawi
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "pih_malawi" }'
+#    - name: Assemble pih_malawi_supervisor
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "pih_malawi_supervisor" }'
+#    - name: Assemble safaridoctors_kenya
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "safaridoctors_kenya" }'
+#    - name: Assemble simprints
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "simprints" }'
+#    - name: Assemble surveillance_covid19_kenya
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "surveillance_covid19_kenya" }'
+#    - name: Assemble trippleeighty
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "trippleeighty" }'
 #    - name: Assemble unbranded_test
 #      uses: maierj/fastlane-action@v1.4.0
 #      with:
 #        lane: build
 #        options: '{ "flavor": "unbranded_test" }'
-    - name: Assemble vhw_burundi
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "vhw_burundi" }'
-    - name: Assemble icm_ph_chc
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "icm_ph_chc" }'
-    - name: Assemble vhtapp_uganda
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "vhtapp_uganda" }'
-    - name: Assemble itech_aurum
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "itech_aurum" }'
-    - name: Assemble itech_aurum
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "itech_malawi" }'
+#    - name: Assemble vhw_burundi
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "vhw_burundi" }'
+#    - name: Assemble icm_ph_chc
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "icm_ph_chc" }'
+#    - name: Assemble vhtapp_uganda
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "vhtapp_uganda" }'
+#    - name: Assemble itech_aurum
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "itech_aurum" }'
+#    - name: Assemble itech_malawi
+#      uses: maierj/fastlane-action@v1.4.0
+#      with:
+#        lane: build
+#        options: '{ "flavor": "itech_malawi" }'
     - name: GitHub release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ assemble-all:
 assemble-all-debug:
 	${GRADLE} ${GRADLE_OPTS} assembleDebug
 
+bundle:
+	${GRADLE} ${GRADLE_OPTS} bundle${flavor}Release
+bundle-all:
+	${GRADLE} ${GRADLE_OPTS} bundleRelease
+
 uninstall-all:
 	${GRADLE} uninstallAll
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean-apks:
 assemble:
 	${GRADLE} ${GRADLE_OPTS} assemble${flavor}
 assemble-all:
-	${GRADLE} ${GRADLE_OPTS} assemble
+	${GRADLE} ${GRADLE_OPTS} assembleRelease
 assemble-all-debug:
 	${GRADLE} ${GRADLE_OPTS} assembleDebug
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ADB = ${ANDROID_HOME}/platform-tools/adb
 GRADLE = ./gradlew
 GRADLE_OPTS = --daemon --parallel
 flavor = UnbrandedWebview
+abi = x86
 
 ifdef ComSpec	 # Windows
   # Use `/` for all paths, except `.\`
@@ -56,6 +57,6 @@ lint:
 test: lint
 	${GRADLE} ${GRADLE_OPTS} test
 test-ui:
-	${GRADLE} connectedUnbrandedWebviewDebugAndroidTest -Pabi=x86 --stacktrace
+	${GRADLE} connectedUnbrandedWebviewDebugAndroidTest -Pabi=${abi} --stacktrace
 test-ui-gamma:
-	${GRADLE} connectedMedicmobilegammaWebviewDebugAndroidTest -Pabi=x86 --stacktrace
+	${GRADLE} connectedMedicmobilegammaWebviewDebugAndroidTest -Pabi=${abi} --stacktrace

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The cht-android application is a thin wrapper to load the [CHT Core Framework](h
 
 # Android App Bundles
 
-Since v0.8.1 the build script produces multiple AABs for publishing to the **Google Play Store**, so the generated `.aab` files need to be uploaded instead of the `.apk` files. For each flavor two bundles are generated, one for each rendering engine: _Webview_ and _Xwalk_.
+The build script produces multiple AABs for publishing to the **Google Play Store**, so the generated `.aab` files need to be uploaded instead of the `.apk` files. For each flavor two bundles are generated, one for each rendering engine: _Webview_ and _Xwalk_.
 
 The AABs are named as follows: `cht-android-{version}-{brand}-{rendering-engine}-release.aab`
 
@@ -131,6 +131,8 @@ The command above builds and assembles the _debug_ and _release_ APKs of the Unb
 Each APK will be generated and stored in `build/outputs/apk/[flavor][Engine]/[debug|release]/`, for example after assembling the _Medicmobiledemo Webview_ flavor with `make flavor=MedicmobiledemoWebview assemble`, the _release_ versions of the APKs generated are stored in `build/outputs/apk/medicmobiledemoWebview/release/`.
 
 To assemble other flavors, use the following command: `make flavour=[Flavor][Engine] assemble`. See the [Flavor selection](#flavor-selection) section for more details about `make` commands.
+
+To create the `.aab` bundle file, use `make bundle`, although signed version are generated when [releasing](#releasing), and the Google Play Store requires signed versions.
 
 To clean the APKs and compiled resources: `make clean`.
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,20 @@ CHT Android App
 
 The cht-android application is a thin wrapper to load the [CHT Core Framework](https://github.com/medic/cht-core/) web application in a webview. This allows the application to be hardcoded to a specific CHT deployment and have a partner specific logo and display name. This app also provides some deeper integration with other android apps and native phone functions that are otherwise unavailable to webapps.
 
+# Android App Bundles
+
+Since v0.8.1 the build script produces multiple AABs for publishing to the **Google Play Store**, so the generated `.aab` files need to be uploaded instead of the `.apk` files. For each flavor two bundles are generated, one for each rendering engine: _Webview_ and _Xwalk_.
+
+The AABs are named as follows: `cht-android-{version}-{brand}-{rendering-engine}-release.aab`
+
+| Rendering engine | Android version |
+|------------------|-----------------|
+| `webview`        | 10+             |
+| `xwalk`          | 4.4 - 9         |
 
 # APKs
 
-For compatibility with a wide range of devices the build script produces multiple APKs. The two variables are the instruction set used by the device's CPU, and the supported Android version. When publishing to the Google Play Store upload all APKs and it will automatically choose the right one for the target device. However, when sideloading the application it is essential to pick the correct APK or the application may crash.
+For compatibility with a wide range of devices the build script produces multiple APKs. The two variables are the instruction set used by the device's CPU, and the supported Android version. When sideloading the application it is essential to pick the correct APK or the application may crash.
 
 To help you pick which APK to install you can find information about the version of Android and the CPU in the About section of the phone's settings menu.
 
@@ -171,16 +181,16 @@ To add a new brand:
 
 ## Alpha for release testing
 
-1. Make sure all issues for this release have passed AT and been merged into `master`
+1. Make sure all issues for this release have passed AT and been merged into `master`.
 2. Create a git tag starting with `v` and ending with the alpha version, e.g. `v1.2.3-alpha.1` and push the tag to GitHub.
-3. Creating this tag will trigger [GitHub Action](https://github.com/medic/cht-android/actions) to build, sign, and properly version the build. The release-ready APKs are available for side-loading from [GitHub Releases](https://github.com/medic/cht-android/releases).
-4. Announce the release in #quality-assurance
+3. Creating this tag will trigger [GitHub Action](https://github.com/medic/cht-android/actions) to build, sign, and properly version the build. The release-ready APKs are available for side-loading from [GitHub Releases](https://github.com/medic/cht-android/releases), along with the AABs that are required to publish in the Google Play Store.
+4. Announce the release in #quality-assurance.
 
 ## Final for users
 
 1. Create a git tag starting with `v`, e.g. `v1.2.3` and push the tag to GitHub. 
 2. The exact same process as Step 3 above.
-3. Publish the unbranded, demo, simprints, and gamma flavors to the Play Store.
+3. Publish the unbranded, demo, simprints, and gamma flavors to the Play Store using the `.aab` files.
 4. Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org), under the "Product - Releases" category.
 5. Each flavor is then individually released to users via "Release Management" in the Google Play Console. Once a flavor has been tested and is ready to go live, click Release to Production
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ def getVersionName = {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   buildToolsVersion '30.0.3'
   packagingOptions {
     exclude 'META-INF/LICENSE'
@@ -70,7 +70,7 @@ android {
   defaultConfig {
     versionName getVersionName()
     archivesBaseName = "${project.name}-${versionName}"
-    targetSdkVersion 29
+    targetSdkVersion 30
     // When upgrading targetSdkVersion, check that the app menu still works on newer devices.
     //for espresso tests
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,8 @@ platform :android do
   lane :build do |options|
     gradle(task: "assemble#{options[:flavor]}WebviewRelease")
     gradle(task: "assemble#{options[:flavor]}XwalkRelease")
-    gradle(task: "bundle#{options[:flavor]}Release")
+    gradle(task: "bundle#{options[:flavor]}WebviewRelease")
+    gradle(task: "bundle#{options[:flavor]}XwalkRelease")
   end
 
   lane :deploy do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,10 +6,10 @@ default_platform(:android)
 
 platform :android do
   lane :build do |options|
-    gradle(task: "assemble#{options[:flavor]}WebviewRelease")
-    gradle(task: "assemble#{options[:flavor]}XwalkRelease")
-    gradle(task: "bundle#{options[:flavor]}WebviewRelease")
-    gradle(task: "bundle#{options[:flavor]}XwalkRelease")
+    gradle(task: "assemble#{options[:flavor]}WebviewRelease", flags: "--daemon --parallel")
+    gradle(task: "assemble#{options[:flavor]}XwalkRelease",   flags: "--daemon --parallel")
+    gradle(task: "bundle#{options[:flavor]}WebviewRelease",   flags: "--daemon --parallel")
+    gradle(task: "bundle#{options[:flavor]}XwalkRelease",     flags: "--daemon --parallel")
   end
 
   lane :deploy do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,7 @@ platform :android do
   lane :build do |options|
     gradle(task: "assemble#{options[:flavor]}WebviewRelease")
     gradle(task: "assemble#{options[:flavor]}XwalkRelease")
+    gradle(task: "bundle#{options[:flavor]}Release")
   end
 
   lane :deploy do |options|
@@ -18,19 +19,15 @@ platform :android do
       package_name: package_name,
       track: "alpha",
       json_key: "playstore-secret.json",
-      apk_paths: [
-        "build/outputs/apk/#{options[:flavor]}Webview/release/cht-android-#{version}-#{options[:flavor]}-webview-arm64-v8a-release.apk",
-        # NOT SUPPORTED WITH: targetSdkVersion 29. Need to add it back to support older Android versions
-        # "build/outputs/apk/#{options[:flavor]}Webview/release/cht-android-#{version}-#{options[:flavor]}-webview-armeabi-v7a-release.apk",
-        "build/outputs/apk/#{options[:flavor]}Xwalk/release/cht-android-#{version}-#{options[:flavor]}-xwalk-arm64-v8a-release.apk",
-        "build/outputs/apk/#{options[:flavor]}Xwalk/release/cht-android-#{version}-#{options[:flavor]}-xwalk-armeabi-v7a-release.apk",
+      aab_paths: [
+        "build/outputs/bundle/#{options[:flavor]}WebviewRelease/cht-android-#{version}-#{options[:flavor]}-webview-release.aab",
+        "build/outputs/bundle/#{options[:flavor]}XwalkRelease/cht-android-#{version}-#{options[:flavor]}-xwalk-release.aab",
       ],
-      skip_upload_aab: true,
+      skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
       validate_only: false,
-
       timeout: 3600,
     )
   end


### PR DESCRIPTION
Upgrade of `targetSdkVersion` to 30 and added build instructions to build `.aab` files, along with a range of other Google Play new requirements.

Issue: #164

## Done
- [x] New targeted SDK ~29~ → 30 (Android 11).
- [x] Assemble AABs files for publishing in Google Play Store.

## TO-DO
- [ ] Check locales configuration when distributing the app with `.aab` format.
- [x] Release a beta version to check CI still works with the changes and releases the AAB files.
- [x] Check lane `deploy` although we are not going to enable it again for publishing in the Play Store.
- [x] Check what happens if we continue signing the new `.aab` files and then Google generates the `.apk` files from there, does Google in some way re-use the sign in the new files? if Google re-sign the APKs with its own signing keys, does it makes the upgrade process for devices with the app already installed to fail?

## No required

These are requirements mention in the Google's documentation (https://developer.android.com/distribute/best-practices/develop/target-sdk) that I have verified we already complain or don't affect our app.

- [x] [APK Signature Scheme v2 now required](https://developer.android.com/about/versions/11/behavior-changes-11#minimum-signature-scheme). We are already signing with v2 scheme. Steps used in the verification:
   1. Download one the last version of the App [Releases](https://github.com/medic/cht-android/releases), any of the APKs.
   2. Check the signature with `apksigner`:
   ```
   $ apksigner verify -v --print-certs cht-android-v0.8.0-5-unbranded-webview-arm64-v8a-release.apk
   Verifies
   Verified using v1 scheme (JAR signing): false
   Verified using v2 scheme (APK Signature Scheme v2): true
   Verified using v3 scheme (APK Signature Scheme v3): false
   Verified using v4 scheme (APK Signature Scheme v4): false
   Verified for SourceStamp: false
   Number of signers: 1
   Signer #1 certificate DN: CN=Unknown, OU=Unknown, O=MedicMobile, L=San Francisco, ST=California, C=CA
   Signer #1 certificate SHA-256 digest: 46e041d3de73ca6ed5844aac3e93728537b67a4e49449859b3c85cdfe41dde90
   ...
   ```
- [x] Do we need to change how we sign bundles letting Google doing that for us? → **No**. _(TODO add sources)_.