### PR TITLE
164 - Target Android 11 and other build changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,25 +3,31 @@ name: Build and test
 on:
   push:
     paths-ignore:
-      - 'README.md'
+      - '**.md'
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - '**.md'
 
 jobs:
+
   build:
+
     name: Build
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+
     - name: Test
+    - uses: actions/checkout@v2
       run: make test
+
     - name: Set up ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
+
     - name: Set up fastlane
       run: gem install fastlane --no-document --quiet
+
     - name: Unpack secrets
       env:
         ANDROID_SECRETS_KEY: ${{ secrets.ANDROID_SECRETS_KEY }}
@@ -29,6 +35,7 @@ jobs:
       run: |
         openssl aes-256-cbc -K $ANDROID_SECRETS_KEY -iv $ANDROID_SECRETS_IV -in secrets.tar.gz.enc -out ./secrets.tar.gz -d
         tar -xf ./secrets.tar.gz
+
     - name: Assemble unbranded
       uses: maierj/fastlane-action@v1.4.0
       env:
@@ -41,20 +48,53 @@ jobs:
         options: '{ "flavor": "unbranded" }'
 
   instrumentation-tests:
+
     name: Instrumentation tests
     runs-on: macos-latest
     steps:
-    - name: checkout
+
+    - name: Checkout
       uses: actions/checkout@v2
-    - name: test unbranded
+
+    - name: Gradle cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+
+    - name: AVD cache
+      uses: actions/cache@v2
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.api-level }}
+
+    - name: Create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
-        arch: x86
+        api-level: 30
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
+    - name: Run test-ui on unbranded
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 30
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui
-    - name: run tests on gamma
+
+    - name: Run test-ui on gamma
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
-        arch: x86
+        api-level: 30
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui-gamma

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 30
+        api-level: 29
         target: google_apis
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -91,7 +91,7 @@ jobs:
     - name: Run test-ui on unbranded
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 30
+        api-level: 29
         target: google_apis
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -100,7 +100,7 @@ jobs:
     - name: Run test-ui on gamma
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 30
+        api-level: 29
         target: google_apis
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,57 +51,57 @@ jobs:
         lane: build
         options: '{ "flavor": "unbranded" }'
 
-  instrumentation-tests:
-
-    name: Instrumentation tests
-    runs-on: macos-latest
-    steps:
-
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Gradle cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
-
-    - name: AVD cache
-      uses: actions/cache@v2
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-${{ matrix.api-level }}
-
-    - name: Create AVD and generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 29
-        target: google_apis
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        script: echo "Generated AVD snapshot for caching."
-
-    - name: Run test-ui on unbranded
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 29
-        target: google_apis
-        force-avd-creation: false
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        script: make test-ui
-
-    - name: Run test-ui on gamma
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 29
-        target: google_apis
-        force-avd-creation: false
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        script: make test-ui-gamma
+#  instrumentation-tests:
+#
+#    name: Instrumentation tests
+#    runs-on: macos-latest
+#    steps:
+#
+#    - name: Checkout
+#      uses: actions/checkout@v2
+#
+#    - name: Gradle cache
+#      uses: actions/cache@v2
+#      with:
+#        path: |
+#          ~/.gradle/caches
+#          ~/.gradle/wrapper
+#        key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+#
+#    - name: AVD cache
+#      uses: actions/cache@v2
+#      id: avd-cache
+#      with:
+#        path: |
+#          ~/.android/avd/*
+#          ~/.android/adb*
+#        key: avd-${{ matrix.api-level }}
+#
+#    - name: Create AVD and generate snapshot for caching
+#      if: steps.avd-cache.outputs.cache-hit != 'true'
+#      uses: reactivecircus/android-emulator-runner@v2
+#      with:
+#        api-level: 29
+#        target: google_apis
+#        force-avd-creation: false
+#        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#        disable-animations: false
+#        script: echo "Generated AVD snapshot for caching."
+#
+#    - name: Run test-ui on unbranded
+#      uses: reactivecircus/android-emulator-runner@v2
+#      with:
+#        api-level: 29
+#        target: google_apis
+#        force-avd-creation: false
+#        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#        script: make test-ui
+#
+#    - name: Run test-ui on gamma
+#      uses: reactivecircus/android-emulator-runner@v2
+#      with:
+#        api-level: 29
+#        target: google_apis
+#        force-avd-creation: false
+#        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#        script: make test-ui-gamma

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: 27
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -90,7 +90,7 @@ jobs:
     - name: Run test-ui on unbranded
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: 27
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui
@@ -98,7 +98,7 @@ jobs:
     - name: Run test-ui on gamma
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: 27
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui-gamma

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
 
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Test
-    - uses: actions/checkout@v2
       run: make test
 
     - name: Set up ruby

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
   instrumentation-tests:
 
     name: Instrumentation tests
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
 
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build and test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   build:
@@ -35,6 +41,7 @@ jobs:
         options: '{ "flavor": "unbranded" }'
 
   instrumentation-tests:
+    name: Instrumentation tests
     runs-on: macos-latest
     steps:
     - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
   instrumentation-tests:
 
     name: Instrumentation tests
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
 
     - name: Checkout
@@ -79,7 +79,7 @@ jobs:
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 30
+        api-level: 29
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -88,7 +88,7 @@ jobs:
     - name: Run test-ui on unbranded
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 30
+        api-level: 29
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui
@@ -96,7 +96,7 @@ jobs:
     - name: Run test-ui on gamma
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 30
+        api-level: 29
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui-gamma

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
   instrumentation-tests:
 
     name: Instrumentation tests
-    runs-on: macos-latest
+    runs-on: macos-10.14
     steps:
 
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
   instrumentation-tests:
 
     name: Instrumentation tests
-    runs-on: macos-10.14
+    runs-on: macos-latest
     steps:
 
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build and test
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - '**.md'
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,8 @@ jobs:
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 27
+        api-level: 30
+        target: google_apis
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -90,7 +91,8 @@ jobs:
     - name: Run test-ui on unbranded
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 27
+        api-level: 30
+        target: google_apis
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui
@@ -98,7 +100,8 @@ jobs:
     - name: Run test-ui on gamma
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 27
+        api-level: 30
+        target: google_apis
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: make test-ui-gamma

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Set release version
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Set up ruby

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,7 +191,7 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "itech_aurum" }'
-    - name: Assemble itech_aurum
+    - name: Assemble itech_malawi
       uses: maierj/fastlane-action@v1.4.0
       with:
         lane: build
@@ -201,6 +201,10 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true
-        files: build/outputs/apk/**/*.apk
+        # APKs for webview-armeabi-v7a are not uploaded
+        files: |
+          build/outputs/apk/**/*-xwalk-arm64-v8a-release.apk
+          build/outputs/apk/**/*-xwalk-armeabi-v7a-release.apk
+          build/outputs/apk/**/*-webview-arm64-v8a-release.apk
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,11 +41,12 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "medicmobilegamma" }'
-    - name: Assemble demo
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "medicmobiledemo" }'
+    # demo app is disabled for now
+    #- name: Assemble demo
+    #  uses: maierj/fastlane-action@v1.4.0
+    #  with:
+    #    lane: build
+    #    options: '{ "flavor": "medicmobiledemo" }'
     - name: Assemble bracuganda
       uses: maierj/fastlane-action@v1.4.0
       with:
@@ -196,6 +197,7 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "itech_malawi" }'
+
     - name: GitHub release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ADB = ${ANDROID_HOME}/platform-tools/adb
 GRADLE = ./gradlew
 GRADLE_OPTS = --daemon --parallel
 flavor = UnbrandedWebview
+abi = x86
 
 ifdef ComSpec	 # Windows
   # Use `/` for all paths, except `.\`
@@ -33,7 +34,7 @@ clean-apks:
 assemble:
 	${GRADLE} ${GRADLE_OPTS} assemble${flavor}
 assemble-all:
-	${GRADLE} ${GRADLE_OPTS} assemble
+	${GRADLE} ${GRADLE_OPTS} assembleRelease
 assemble-all-debug:
 	${GRADLE} ${GRADLE_OPTS} assembleDebug
 
@@ -51,6 +52,6 @@ lint:
 test: lint
 	${GRADLE} ${GRADLE_OPTS} test
 test-ui:
-	${GRADLE} connectedUnbrandedWebviewDebugAndroidTest -Pabi=x86 --stacktrace
+	${GRADLE} connectedUnbrandedWebviewDebugAndroidTest -Pabi=${abi} --stacktrace
 test-ui-gamma:
-	${GRADLE} connectedMedicmobilegammaWebviewDebugAndroidTest -Pabi=x86 --stacktrace
+	${GRADLE} connectedMedicmobilegammaWebviewDebugAndroidTest -Pabi=${abi} --stacktrace

--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ To add a new brand:
 
 ## Alpha for release testing
 
-1. Make sure all issues for this release have passed AT and been merged into `master`
+1. Make sure all issues for this release have passed AT and been merged into `master`.
 2. Create a git tag starting with `v` and ending with the alpha version, e.g. `v1.2.3-alpha.1` and push the tag to GitHub.
 3. Creating this tag will trigger [GitHub Action](https://github.com/medic/cht-android/actions) to build, sign, and properly version the build. The release-ready APKs are available for side-loading from [GitHub Releases](https://github.com/medic/cht-android/releases).
-4. Announce the release in #quality-assurance
+4. Announce the release in #quality-assurance.
 
 ## Final for users
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To add a new brand:
 2. The exact same process as Step 3 above.
 3. Publish the unbranded, simprints, and gamma flavors to the Play Store.
 4. Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org), under the "Product - Releases" category.
-5. Each flavor is then individually released to users via "Release Management" in the Google Play Console. Once a flavor has been tested and is ready to go live, click Release to Production
+5. Each flavor is then individually released to users via "Release Management" in the Google Play Console. Once a flavor has been tested and is ready to go live, click Release to Production.
 
 
 # Copyright

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See the [Makefile](./Makefile) for more details.
 
 The command above builds and assembles the _debug_ and _release_ APKs of the Unbranded Webview version of the app.
 
-Each APK will be generated and stored in `build/outputs/apk/[flavor][Engine]/[debug|release]/`, for example after assembling the _Medicmobiledemo Webview_ flavor with `make flavor=MedicmobiledemoWebview assemble`, the _release_ versions of the APKs generated are stored in `build/outputs/apk/medicmobiledemoWebview/release/`.
+Each APK will be generated and stored in `build/outputs/apk/[flavor][Engine]/[debug|release]/`, for example after assembling the _Simprints Webview_ flavor with `make flavor=SimprintsWebview assemble`, the _release_ versions of the APKs generated are stored in `build/outputs/apk/simprintsWebview/release/`.
 
 To assemble other flavors, use the following command: `make flavour=[Flavor][Engine] assemble`. See the [Flavor selection](#flavor-selection) section for more details about `make` commands.
 
@@ -180,7 +180,7 @@ To add a new brand:
 
 1. Create a git tag starting with `v`, e.g. `v1.2.3` and push the tag to GitHub. 
 2. The exact same process as Step 3 above.
-3. Publish the unbranded, demo, simprints, and gamma flavors to the Play Store.
+3. Publish the unbranded, simprints, and gamma flavors to the Play Store.
 4. Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org), under the "Product - Releases" category.
 5. Each flavor is then individually released to users via "Release Management" in the Google Play Console. Once a flavor has been tested and is ready to go live, click Release to Production
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Earlier releases are no longer accepted by the Google Play Store.
 
 ### Changes
 
-- [improvement] [cht-android#106](https://github.com/medic/cht-android/issues/106): Update target SDK version to 29 for Play Store compliance
+- [improvement] [cht-android#106](https://github.com/medic/cht-android/issues/106): Update target SDK version to 29 for Play Store compliance.
 
 ## 0.5.0
 
@@ -162,9 +162,9 @@ To build and deploy APKs for all configured brands:
 
 To add a new brand:
 
-1. add `productFlavors { <new_brand> { ... } }` in `build.gradle`
-2. add icons, strings etc. in `src/<new_brand>`
-3. to enable automated deployments, add the `new_brand` to `.github/workflows/publish.yml`
+1. add `productFlavors { <new_brand> { ... } }` in `build.gradle`.
+2. add icons, strings etc. in `src/<new_brand>`.
+3. to enable automated deployments, add the `new_brand` to `.github/workflows/publish.yml`.
 
 
 # Releasing
@@ -187,7 +187,7 @@ To add a new brand:
 
 # Copyright
 
-Copyright 2013-2021 Medic Mobile, Inc. <hello@medic.org>
+Copyright 2013-2021 Medic Mobile, Inc. <hello@medic.org>.
 
 
 # License

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ def getVersionName = {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   buildToolsVersion '30.0.3'
   packagingOptions {
     exclude 'META-INF/LICENSE'
@@ -70,7 +70,7 @@ android {
   defaultConfig {
     versionName getVersionName()
     archivesBaseName = "${project.name}-${versionName}"
-    targetSdkVersion 29
+    targetSdkVersion 30
     // When upgrading targetSdkVersion, check that the app menu still works on newer devices.
     //for espresso tests
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/src/androidTestMedicmobilegammaWebviewDebug/java/org/medicmobile/webapp/mobile/LoginTests.java
+++ b/src/androidTestMedicmobilegammaWebviewDebug/java/org/medicmobile/webapp/mobile/LoginTests.java
@@ -57,7 +57,7 @@ public class LoginTests {
 								0)))
 				.atPosition(2);
 		linearLayout.perform(click());
-		Thread.sleep(12000);//TODO: use better ways to handle delays
+		Thread.sleep(7000);//TODO: use better ways to handle delays
 
 		ViewInteraction webView = onView(
 				allOf(withId(R.id.wbvMain),

--- a/src/androidTestUnbrandedWebviewDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
+++ b/src/androidTestUnbrandedWebviewDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
@@ -92,7 +92,7 @@ public class SettingsDialogActivityTest {
 								0)))
 				.atPosition(2);
 		linearLayout.perform(click());
-		Thread.sleep(12000);	//TODO: use better ways to handle delays
+		Thread.sleep(7000);	//TODO: use better ways to handle delays
 
 		ViewInteraction webView = onView(
 				allOf(withId(R.id.wbvMain),


### PR DESCRIPTION
Spin-off of the PR #193 , I move the change to target Android 11 that will be required next month for releasing new versions of existing apps, while leaving the original PR for the implementation of the new workflow for publishing new apps that will require more changes in the building and signing process.

### Changes
- New targeted SDK ~29~ → 30 (Android 11).
- Skip upload of APKs for webview-armeabi-v7a arch that is an architecture not used in devices with Android 10+.
- Skip CI build process if only README changes are pushed.
-  Allow `abi` argument to be overwritten in UI tests.
- `make assemble-all` only assemble release versions: there is a task to assemble the debug version (`assemble-all-debug`) and it's unlikely somebody will want to generate both. Furthermore, triggering the assembling of all versions cause the process to spend more than 2 Gb of space, and some time goes out of memory in doing so, even disabling the `--parallel` argument.


