### PR TITLE
201 - Upgrade Android Gradle Plugin, Java and fix lint issues to keep up-to-date with Play Store rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: '11''11'
+        java-version: '11'
 
     - name: Test
       run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Set up Java 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
+
     - name: Gradle cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Set up Java 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11''11'
+
     - name: Test
       run: make test
 
-    - name: Set up ruby
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
 
-    - name: Set up fastlane
+    - name: Set up Fastlane
       run: gem install fastlane --no-document --quiet
 
     - name: Unpack secrets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,27 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     steps:
+
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Set release version
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - name: Set up ruby
+
+    - name: Set up Java 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
+
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
-    - name: Set up fastlane
+
+    - name: Set up Fastlane
       run: gem install fastlane --no-document --quiet
+
     - name: Unpack secrets
       env:
         ANDROID_SECRETS_KEY: ${{ secrets.ANDROID_SECRETS_KEY }}
@@ -32,6 +43,7 @@ jobs:
       run: |
         openssl aes-256-cbc -K $ANDROID_SECRETS_KEY -iv $ANDROID_SECRETS_IV -in secrets.tar.gz.enc -out ./secrets.tar.gz -d
         tar -xf ./secrets.tar.gz
+
     - name: Assemble unbranded
       uses: maierj/fastlane-action@v1.4.0
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import com.android.build.OutputFile
-
 buildscript {
   repositories {
     mavenCentral()
@@ -8,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.2'
+    classpath 'com.android.tools.build:gradle:7.0.0'
     classpath 'com.noveogroup.android:check:1.2.5'
   }
 }
@@ -85,8 +83,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 
   applicationVariants.all { variant ->
@@ -120,7 +118,7 @@ android {
     // Every APK requires a unique version code.
     // So when compiling multiple APKS for the different ABIs, use the first digit
     variant.outputs.each { output ->
-      def versionAugmentation = (output.getFilter(OutputFile.ABI) == 'arm64-v8a') ? 1 : 0;
+      def versionAugmentation = (output.getFilter(com.android.build.OutputFile.ABI) == 'arm64-v8a') ? 1 : 0;
       output.versionCodeOverride = variant.versionCode * 10 + versionAugmentation
     }
   }
@@ -366,7 +364,7 @@ dependencies {
   implementation 'com.simprints:LibSimprints:1.0.11'
   implementation 'com.github.Mariovc:ImagePicker:1.2.2'
   xwalkImplementation files('src/xwalk/libs/xwalk_core_library-23.53.589.4-arm64-v8a.aar')
-  testImplementation 'junit:junit:4.12'
+  testImplementation 'junit:junit:4.13.1'
   testImplementation 'com.google.android:android-test:4.1.1.4'
   testImplementation 'org.robolectric:robolectric:4.3'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
       android:allowBackup="false"
       android:largeHeap="true"
       tools:ignore="GoogleAppIndexingWarning,LockedOrientationActivity,Instantiatable">
-    <activity android:name="StartupActivity">
+    <activity android:name="StartupActivity" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER" />
@@ -50,7 +50,8 @@
     <activity android:name="RequestPermissionActivity"
         android:screenOrientation="portrait"/>
     <activity android:name="AppUrlIntentActivity"
-        android:launchMode="singleInstance">
+        android:launchMode="singleInstance"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -60,4 +60,16 @@
       </intent-filter>
     </activity>
   </application>
+
+  <queries>
+    <intent>
+      <action android:name="android.media.action.IMAGE_CAPTURE" />
+    </intent>
+    <intent>
+      <action android:name="simprints.app" />
+    </intent>
+    <intent>
+      <action android:name="medic.mrdt.verify" />
+    </intent>
+  </queries>
 </manifest>

--- a/src/main/java/org/medicmobile/webapp/mobile/FreeSpaceWarningActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/FreeSpaceWarningActivity.java
@@ -9,7 +9,7 @@ import static org.medicmobile.webapp.mobile.Utils.startAppActivityChain;
 
 public class FreeSpaceWarningActivity extends LockableActivity {
 	/** Recommended minimum free space on the device, in bytes */
-	static final long MINIMUM_SPACE = 200 * 1024 * 1024;
+	static final long MINIMUM_SPACE = 200L * 1024 * 1024;
 
 	@Override public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);

--- a/src/main/java/org/medicmobile/webapp/mobile/SmsSender.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/SmsSender.java
@@ -107,6 +107,7 @@ class SmsSender {
 		return intents;
 	}
 
+	@SuppressLint("UnspecifiedImmutableFlag")
 	private PendingIntent intentFor(String intentType, String id, String destination, String content, int partIndex, int totalParts) {
 		Intent intent = new Intent(intentType);
 		intent.putExtra("id", id);

--- a/src/main/res/values-ne/strings.xml
+++ b/src/main/res/values-ne/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 	<string name="locRequestTitle">स्थान पहुँच</string>
-	<string name="locRequestMessage">यो अनुप्रयोगले विश्लेषण गर्दछ र तपाईंको क्षेत्रमा स्वास्थ्य परिणामहरू सुधार गर्न स्थान डाटा संकलन गर्दछ। स्थान पहुँचलाई अनुमति दिन "खोल्नुहोस्" चयन गर्नुहोस्, र त्यसपछि अर्को प्रॉम्प्ट पुष्टि गर्नुहोस्।</string>
+	<string name="locRequestMessage" tools:ignore="StringFormatInvalid">यो अनुप्रयोगले विश्लेषण गर्दछ र तपाईंको क्षेत्रमा स्वास्थ्य परिणामहरू सुधार गर्न स्थान डाटा संकलन गर्दछ। स्थान पहुँचलाई अनुमति दिन "खोल्नुहोस्" चयन गर्नुहोस्, र त्यसपछि अर्को प्रॉम्प्ट पुष्टि गर्नुहोस्।</string>
 	<string name="locRequestOkButton">खोल्नुहोस्</string>
 	<string name="locRequestDenyButton">हुँदैन, धन्यबाद</string>
 	<string name="locRequestIconDescription">मेरो स्थान आइकन</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -40,8 +40,8 @@
 	<string name="tstUnlock_confirmFailed">Code does not match - try again</string>
 
 	<string name="txtFreeSpaceWarning">Space is running low on this device. CHT-Android may not be able to start, or may perform strangely.</string>
-	<string name="txtFreeSpaceCurrent">Current space:\n%s MB</string>
-	<string name="txtFreeSpaceRecommended">Recommended space:\n%s MB</string>
+	<string name="txtFreeSpaceCurrent">Current space:\n%d MB</string>
+	<string name="txtFreeSpaceRecommended">Recommended space:\n%d MB</string>
 
 	<string name="promptChooseFile">Choose file</string>
 	<string name="promptChooseImage">Choose image</string>


### PR DESCRIPTION
Issue: #201 

Update to the last Android Gradle Plugin is not a strict requirement from Google, unless you still want to run linters :man_shrugging:

The linter of the old plugin was running OK, but it has a rule: when connection is available it checks whether the plugin is up to date, and although it does not require to have the last version installed, now it started to ask to update to the last version 7.0.0, if not, the lint process fails.

Moreover, after updating to the last version, because the plugin was developed with JDK 11, it requires at least to invoke Gradle with that version or higher, so we also added that version as minimal version to compile the project, although changes in the Java source code were not needed, but we can benefit in a future from this update.

Finally, the new plugin added more and better checks, some also aligned with the new requirements in Android 11 that are addressed in this PR:
- Errors of how `String.format` was used (although the formatting was safe).
- Set explicitly `android:exported="true"` to "public" activities (it will become a requirement in Android 12+)
- Add manifest declaration for querying intents and prevent linter errors. This declaration prevent Android 11+ to return restricted results about apps and intents available in the device.

### TO-DO
The last linter is a warning that integrations with other apps through intents may not work if not declared as it is now with this PR, so we have to check that the following integrations continue to work:

~- [x] Camera~ → this feature is disabled and will be re-enabled in the v1.0.0 release.
~- [x] Simprints~ → We cannot test this integration because it is not working the widget in the CHT, I have created separated issues to keep track of that.
- [x] MRDT → This PR makes the integration to works again in Android 11, confirmed testing the app locally