### PR TITLE
Bumping up  com.android.tools.build:gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.0.0'
+    classpath 'com.android.tools.build:gradle:7.0.1'
     classpath 'com.noveogroup.android:check:1.2.5'
   }
 }


### PR DESCRIPTION
**Description**
Bumping up  com.android.tools.build:gradle to v7.0.1 for fixing lint errors

**License**
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.