### PR TITLE
Skip CI jobs when is not needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on: [push, pull_request]
 
 jobs:
 
-  pre_job:
+  skip_check:
 
-    name: Pre Job
+    name: Skip Check
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -21,8 +21,8 @@ jobs:
 
     name: Build
     runs-on: ubuntu-latest
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
 
     - name: Checkout
@@ -70,8 +70,8 @@ jobs:
 
     name: Instrumentation tests
     runs-on: macos-latest
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
 
     - name: Checkout


### PR DESCRIPTION
Skip CI jobs when is not needed:

- When changes are made only in markdown files (README, CHANGELOG).
- When duplicated jobs are launched over the same code on different events.

Also change the Ubuntu 18.04 machine used to run the jobs by a Ubuntu **latest** machine, as we do in other projects.

The magic is done by [actions/skip-duplicate-actions](https://github.com/marketplace/actions/skip-duplicate-actions) , that acts as a "pre" jobs to verify whether the rest of the jobs should be executed or skipped.

The job duplication is not always avoided, it depends on when the first set of jobs were created (the ones created when pushing) and whether the PR for that branch that launches the other set of jobs is created too earlier or not, so not always works in this case. Also I tested in another repo and looks like it works well when the PR was based on the last commit on master, and then when you finally rebase and push to master, the jobs for the "push" event are skipped as expected.

NOTE: After this PR we should create another dummy PR changing the README file and see if it works well, and also taking into account the branch rule protections, although it should work because CI is executed, regardless of whether some jobs are skipped or not.