### PR TITLE
CI skip newer jobs with same content

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
+          concurrent_skipping: 'same_content_newer'
           paths_ignore: '["**.md"]'
 
 


### PR DESCRIPTION
With this option CI would effectively skip new jobs with the same content, **even if they are running in parallel**.

The problem with the current implementation is that in practice only avoided jobs running after merging PRs into master that were up to date with the HEAD of master, but it didn't prevent jobs launched at the same time when you pushed changes unless they were really fast to run, because the default configuration only took into account new jobs against already executed jobs.