### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+
+---
+
+**Important**: This is a public repository. Anyone in the world can see what's posted here. If you are posting screenshots or log files, please **carefully examine them for** the presence of any kind of **protected health information** (PHI). Images or logs containing PHI _must_ be posted in fully-redacted form, with no visible PHI.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, include the server or browser logs.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+- Instance: (eg: alpha.dev.medicmobile.org, etc)
+- Android Version: (eg: 4.4, 11, etc)
+- App Version: (eg: 0.7.3, 0.9.0, etc)
+
+**Additional context**
+Add any other context about the problem here. What have you tried? Is there a workaround?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'Type: Feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,20 @@
+---
+name: Improvement
+about: Suggest something to make an existing feature better
+title: ''
+labels: 'Type: Improvement'
+assignees: ''
+
+---
+
+**What feature do you want to improve?**
+A clear and concise description of what the problem is. Ex. It would be better to [...]
+
+**Describe the improvement you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,14 @@
+---
+name: Support request
+about: Ask for assistance
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+READ THIS FIRST
+
+The best way to get support and answers to questions is by posting on the CHT Forum as it has high engagement amongst the wider CHT community so you're more likely to get the answer you need.
+
+Please raise your request on the Forum: https://forum.communityhealthtoolkit.org

--- a/.github/ISSUE_TEMPLATE/technical_issue.md
+++ b/.github/ISSUE_TEMPLATE/technical_issue.md
@@ -1,0 +1,17 @@
+---
+name: Technical issue
+about: Suggest an improvement users won't notice
+title: ''
+labels: 'Type: Technical issue'
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the problem is.
+
+**Describe the improvement you'd like**
+A clear and concise description of what you want to change.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -27,7 +27,7 @@ Once all issues have passed acceptance testing and have been merged into `master
 
 - [ ] Create a new release branch from `master` named `v<major>.<minor>.x`.
 - [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#alpha-for-release-testing).
-  - Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+  - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
 - [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). 
   - [ ] Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. 
   - [ ] Document any known migration steps and known issues.

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -1,7 +1,7 @@
 ---
 name: Major/minor release
 about: Schedule a major or minor release
-title: 'Release x.y.z'
+title: 'Release vX.Y.Z'
 labels: 'Type: Internal process'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -27,13 +27,18 @@ Once all issues have passed acceptance testing and have been merged into `master
 
 - [ ] Create a new release branch from `master` named `v<major>.<minor>.x`.
 - [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#alpha-for-release-testing).
-- [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
   - Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+- [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). 
+  - [ ] Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. 
+  - [ ] Document any known migration steps and known issues.
+  - [ ] Provide description, screenshots, videos, and anything else to help communicate particularly important changes. 
+  - [ ] Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). 
+  - [ ] Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
 - [ ] Create a release in GitHub as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#production-release).
   
 # Publishing - Release Engineer
 
-- [ ] Download the 3 `.apk` files (or 2 `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
+- [ ] Download the `.apk` files (or `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
   - `medicmobilegamma`
   - `unbranded`
 - [ ] Publish a release for each flavor as described in the [publishing docs](https://docs.communityhealthtoolkit.org/core/guides/android/publishing/#google-play-store).

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -25,23 +25,18 @@ When development is ready to begin one of the engineers should be nominated as a
 
 Once all issues have passed acceptance testing and have been merged into `master` release testing can begin.
 
-- [ ] Create a new release branch from `master` named `<major>.<minor>.x` in `cht-android`.
-- [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` by pushing a git tag and when CI completes successfully notify the QA team that it's ready for release testing.
-- [ ] Create a `release_notes_<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
-- [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
-- [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-android/releases) with the naming convention `v<major>.<minor>.<patch>`. This will create the git tag automatically. Repeat the release notes in the description of the release.
-- [ ] Confirm the release build completes successfully and the new artifacts are available as assets on the release in GitHub.
+- [ ] Create a new release branch from `master` named `v<major>.<minor>.x` in `cht-android`.
+- [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#alpha-for-release-testing).
+- [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+  - Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+- [ ] Create a release in GitHub as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#production-release).
   
 # Publishing - Release Engineer
 
 - [ ] Download the 3 `.apk` files (or 2 `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
   - `medicmobilegamma`
   - `unbranded`
-- [ ] In the [Google Play Console](https://play.google.com/console), for each flavor, create a new `Production` release.
-  - Upload app bundles for the flavor
-  - Use the new cht-android version as the Release name
-  - Add a one sentence summary of the CHANGELOG entry as the Release notes.
-- [ ] From the `Releases overview` page in the Google Play Console, confirm that the Release status for the new release is "Available on Google Play" (this could take hours or days).
+- [ ] Publish a release for each flavor as described in the [publishing docs](https://docs.communityhealthtoolkit.org/core/guides/android/publishing/#google-play-store).
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:
 ```
 *We're excited to announce the release of [{{version}}](https://github.com/medic/cht-android/releases/tag/{{version}}) of cht-android*

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -25,7 +25,7 @@ When development is ready to begin one of the engineers should be nominated as a
 
 Once all issues have passed acceptance testing and have been merged into `master` release testing can begin.
 
-- [ ] Create a new release branch from `master` named `v<major>.<minor>.x` in `cht-android`.
+- [ ] Create a new release branch from `master` named `v<major>.<minor>.x`.
 - [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#alpha-for-release-testing).
 - [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
   - Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -33,7 +33,7 @@ Once all issues have passed acceptance testing and have been merged into `master
   - [ ] Document any known migration steps and known issues.
   - [ ] Provide description, screenshots, videos, and anything else to help communicate particularly important changes. 
   - [ ] Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). 
-  - [ ] Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+  - [ ] Assign the PR to the Director of Technology to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
 - [ ] Create a release in GitHub as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#production-release).
   
 # Publishing - Release Engineer

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -1,0 +1,53 @@
+---
+name: Major/minor release
+about: Schedule a major or minor release
+title: 'Release x.y.z'
+labels: 'Type: Internal process'
+assignees: ''
+
+---
+
+# Planning - Product Manager
+
+- [ ] Create a GH Milestone for the release. We use [semver](http://semver.org) so if there are breaking changes increment the major, otherwise if there are new features increment the minor, otherwise increment the service pack. Breaking changes in our case relate to updated software requirements (egs: minimum Android versions), broken backwards compatibility in an api, or a major visual update that requires user retraining.
+- [ ] Add all the issues to be worked on to the Milestone. Ideally each minor release will have one or two features, a handful of improvements, and plenty of bug fixes.
+- [ ] Identify any features and improvements in the release that need end-user documentation (beyond eng team documentation improvements) and create corresponding issues in the cht-docs repo
+- [ ] Assign an engineer as Release Engineer for this release.
+
+# Development - Release Engineer
+
+When development is ready to begin one of the engineers should be nominated as a Release Engineer. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
+
+- [ ] Raise a new issue called `Update dependencies for <version>`. This should be done early in the release cycle so find a volunteer to take this on and assign it to them.
+- [ ] Write an update in the weekly Product Team call agenda summarising development and acceptance testing progress and identifying any blockers. The release Engineer is to update this every week until the version is released.
+
+# Releasing - Release Engineer
+
+Once all issues have passed acceptance testing and have been merged into `master` release testing can begin.
+
+- [ ] Create a new release branch from `master` named `<major>.<minor>.x` in `cht-android`.
+- [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` by pushing a git tag and when CI completes successfully notify the QA team that it's ready for release testing.
+- [ ] Create a `release_notes_<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+- [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+- [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-android/releases) with the naming convention `v<major>.<minor>.<patch>`. This will create the git tag automatically. Repeat the release notes in the description of the release.
+- [ ] Confirm the release build completes successfully and the new artifacts are available as assets on the release in GitHub.
+  
+# Publishing - Release Engineer
+
+- [ ] Download the 3 `.apk` files (or 2 `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
+  - `medicmobilegamma`
+  - `unbranded`
+- [ ] In the [Google Play Console](https://play.google.com/console), for each flavor, create a new `Production` release.
+  - Upload app bundles for the flavor
+  - Use the new cht-android version as the Release name
+  - Add a one sentence summary of the CHANGELOG entry as the Release notes.
+- [ ] From the `Releases overview` page in the Google Play Console, confirm that the Release status for the new release is "Available on Google Play" (this could take hours or days).
+- [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:
+```
+*We're excited to announce the release of [{{version}}](https://github.com/medic/cht-android/releases/tag/{{version}}) of cht-android*
+
+New features include {{key_features}}. We've also implemented loads of other improvements and fixed a heap of bugs.
+
+Read the release notes for full details: {{url}}
+```
+- [ ] Mark this issue "done" and close the Milestone.

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -22,22 +22,17 @@ When development is ready to begin one of the engineers should be nominated as a
 
 Once all issues have passed acceptance testing and have been merged into `master` and backported to the release branch release testing can begin.
 
-- [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` by pushing a git tag and when CI completes successfully notify the QA team that it's ready for release testing.
-- [ ] Create a `release_notes_<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
-- [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
-- [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-android/releases) with the naming convention `v<major>.<minor>.<patch>`. This will create the git tag automatically. Repeat the release notes in the description of the release.
-- [ ] Confirm the release build completes successfully and the new artifacts are available as assets on the release in GitHub.
+- [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#alpha-for-release-testing).
+- [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+  - Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+- [ ] Create a release in GitHub as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#production-release).
 
 # Publishing - Release Engineer
 
 - [ ] Download the 3 `.apk` files (or 2 `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
   - `medicmobilegamma`
   - `unbranded`
-- [ ] In the [Google Play Console](https://play.google.com/console), for each flavor, create a new `Production` release.
-  - Upload app bundles for the flavor
-  - Use the new cht-android version as the Release name
-  - Add a one sentence summary of the CHANGELOG entry as the Release notes.
-- [ ] From the `Releases overview` page in the Google Play Console, confirm that the Release status for the new release is "Available on Google Play" (this could take hours or days).
+- [ ] Publish a release for each flavor as described in the [publishing docs](https://docs.communityhealthtoolkit.org/core/guides/android/publishing/#google-play-store).
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:
 ```
 *Announcing the release of [{{version}}](https://github.com/medic/cht-android/releases/tag/{{version}}) of cht-android*

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -1,0 +1,47 @@
+---
+name: Patch release
+about: Schedule a patch release
+title: 'Release x.y.z'
+labels: 'Type: Internal process'
+assignees: ''
+
+---
+
+# Planning - Product Manager
+
+- [ ] Create an GH Milestone and add this issue to it.
+- [ ] Add all the issues to be worked on to the Milestone.
+
+# Development - Release Engineer
+
+When development is ready to begin one of the engineers should be nominated as a Release Engineer. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
+
+- [ ] Write an update in the weekly Product Team call agenda summarising development and acceptance testing progress and identifying any blockers. The Release Engineer is to update this every week until the version is released.
+
+# Releasing - Release Engineer
+
+Once all issues have passed acceptance testing and have been merged into `master` and backported to the release branch release testing can begin.
+
+- [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` by pushing a git tag and when CI completes successfully notify the QA team that it's ready for release testing.
+- [ ] Create a `release_notes_<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+- [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+- [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-android/releases) with the naming convention `v<major>.<minor>.<patch>`. This will create the git tag automatically. Repeat the release notes in the description of the release.
+- [ ] Confirm the release build completes successfully and the new artifacts are available as assets on the release in GitHub.
+
+# Publishing - Release Engineer
+
+- [ ] Download the 3 `.apk` files (or 2 `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
+  - `medicmobilegamma`
+  - `unbranded`
+- [ ] In the [Google Play Console](https://play.google.com/console), for each flavor, create a new `Production` release.
+  - Upload app bundles for the flavor
+  - Use the new cht-android version as the Release name
+  - Add a one sentence summary of the CHANGELOG entry as the Release notes.
+- [ ] From the `Releases overview` page in the Google Play Console, confirm that the Release status for the new release is "Available on Google Play" (this could take hours or days).
+- [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:
+```
+*Announcing the release of [{{version}}](https://github.com/medic/cht-android/releases/tag/{{version}}) of cht-android*
+
+This release fixes {{number of bugs}}. Read the release notes for full details: {{url}}
+```
+- [ ] Mark this issue "done" and close the Milestone.

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -29,7 +29,7 @@ Once all issues have passed acceptance testing and have been merged into `master
   - [ ] Document any known migration steps and known issues.
   - [ ] Provide description, screenshots, videos, and anything else to help communicate particularly important changes.
   - [ ] Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway).
-  - [ ] Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+  - [ ] Assign the PR to the Director of Technology to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
 - [ ] Create a release in GitHub as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#production-release).
 
 # Publishing - Release Engineer

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -23,13 +23,18 @@ When development is ready to begin one of the engineers should be nominated as a
 Once all issues have passed acceptance testing and have been merged into `master` and backported to the release branch release testing can begin.
 
 - [ ] Build an alpha named `v<major>.<minor>.<patch>-alpha.1` as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#alpha-for-release-testing).
-- [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md). Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
-  - Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+  - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another alpha.
+- [ ] Create a `release_notes_v<major>.<minor>.<patch>` branch from `master` and add a new section in the [CHANGELOG](https://github.com/medic/cht-android/blob/master/CHANGELOG.md).
+  - [ ] Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions.
+  - [ ] Document any known migration steps and known issues.
+  - [ ] Provide description, screenshots, videos, and anything else to help communicate particularly important changes.
+  - [ ] Document any required or recommended upgrades to our other products (eg: cht-core, cht-conf, cht-gateway).
+  - [ ] Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
 - [ ] Create a release in GitHub as described in the [release docs](https://docs.communityhealthtoolkit.org/core/guides/android/releasing/#production-release).
 
 # Publishing - Release Engineer
 
-- [ ] Download the 3 `.apk` files (or 2 `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
+- [ ] Download the `.apk` files (or `.aab` files) from the assets on the release in GitHub for each reference flavor to publish:
   - `medicmobilegamma`
   - `unbranded`
 - [ ] Publish a release for each flavor as described in the [publishing docs](https://docs.communityhealthtoolkit.org/core/guides/android/publishing/#google-play-store).

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -1,7 +1,7 @@
 ---
 name: Patch release
 about: Schedule a patch release
-title: 'Release x.y.z'
+title: 'Release vX.Y.Z'
 labels: 'Type: Internal process'
 assignees: ''
 


### PR DESCRIPTION
I specifically was interested in having a template for "release issues" similar to `cht-core`, but it seemed to make sense to include the rest too (except for the [performance](https://github.com/medic/cht-core/blob/master/.github/ISSUE_TEMPLATE/performance.md) template since it seems unlikely that there would be sufficient performance issues in cht-android to necessitate a bespoke template.

I am open to other approaches here if this does not seem like the best way, but it felt reasonable to start with something close to `cht-core` and go from there.