### PR TITLE
Adding test coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ lint: pmd checkstyle spotbugs
 test: lint
 	${GRADLE} ${GRADLE_OPTS} test
 
+test-coverage:
+	${GRADLE} ${GRADLE_OPTS} makeUnbrandedDebugUnitTestCoverageReport
+
 test-ui:
 	${GRADLE} connectedUnbrandedDebugAndroidTest \
 		-Pabi=${abi} --stacktrace -Pandroid.testInstrumentationRunnerArguments.class=\

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 apply plugin: 'pmd'
 apply plugin: 'com.github.spotbugs'
+apply from: 'coverage.gradle'
 
 // enable verbose lint warnings
 gradle.projectsEvaluated {

--- a/coverage.gradle
+++ b/coverage.gradle
@@ -13,11 +13,9 @@ project.afterEvaluate {
   tasks.create(name: "make${testType}CoverageReport", type: JacocoReport, dependsOn: testTaskName) {
     group = 'Reporting'
     description = "Generate Jacoco coverage report for the ${variantName} build."
-    onlyIf = { true }
 
     reports {
       html.enabled(true)
-      xml.enabled(true)
     }
 
     def excludes = [
@@ -28,8 +26,6 @@ project.afterEvaluate {
       '**/*Test*.*',
       'android/**/*.*',
       'androidx/**/*.*',
-      '**/*$ViewInjector*.*',
-      '**/*MembersInjector*.*',
       '**/*_Factory.*',
       '**/*_Provide*Factory*.*',
       '**/*_ViewBinding*.*',
@@ -41,10 +37,10 @@ project.afterEvaluate {
       '**/*Binding.*'
     ]
 
-    classDirectories.from = files([fileTree(
+    classDirectories.from = files(fileTree(
       dir: "${project.buildDir}/intermediates/javac/${variantName}/classes",
       excludes: excludes
-    )])
+    ))
     sourceDirectories.from = file("${project.projectDir}/src/main/java")
     executionData.from = file("${project.buildDir}/outputs/unit_test_code_coverage/${testType}/${testTaskName}.exec")
   }

--- a/coverage.gradle
+++ b/coverage.gradle
@@ -1,0 +1,53 @@
+apply plugin: 'jacoco'
+
+jacoco {
+  toolVersion '0.8.7'
+}
+
+tasks.withType(Test) {
+  jacoco.includeNoLocationClasses = true
+  jacoco.excludes = ['jdk.internal.*']
+}
+
+project.afterEvaluate {
+  def variantName = 'unbrandedDebug'
+  def testTaskName = "test${variantName.capitalize()}UnitTest"
+
+  tasks.create(name: "${variantName}Coverage", type: JacocoReport, dependsOn: testTaskName) {
+    group = 'Reporting'
+    description = "Generate Jacoco coverage reports for the ${variantName} build."
+
+    reports {
+      html.enabled(true)
+      xml.enabled(true)
+    }
+
+    def excludes = [
+      '**/R.class',
+      '**/R$*.class',
+      '**/BuildConfig.*',
+      '**/Manifest*.*',
+      '**/*Test*.*',
+      'android/**/*.*',
+      'androidx/**/*.*',
+      '**/*$ViewInjector*.*',
+      '**/*Dagger*.*',
+      '**/*MembersInjector*.*',
+      '**/*_Factory.*',
+      '**/*_Provide*Factory*.*',
+      '**/*_ViewBinding*.*',
+      '**/AutoValue_*.*',
+      '**/R2.class',
+      '**/R2$*.class',
+      '**/*Directions$*',
+      '**/*Directions.*',
+      '**/*Binding.*'
+    ]
+
+    def javaClasses = fileTree(dir: "${project.buildDir}/intermediates/javac/${variantName}/classes", excludes: excludes)
+    classDirectories.from = files([javaClasses])
+    sourceDirectories.from = files(["${project.projectDir}/src/main/java"])
+
+    executionData.from = files(["${project.buildDir}/jacoco/${testTaskName}.exec"])
+  }
+}

--- a/coverage.gradle
+++ b/coverage.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'jacoco'
 
-jacoco {
-  toolVersion '0.8.7'
-}
-
 tasks.withType(Test) {
   jacoco.includeNoLocationClasses = true
   jacoco.excludes = ['jdk.internal.*']
@@ -11,11 +7,13 @@ tasks.withType(Test) {
 
 project.afterEvaluate {
   def variantName = 'unbrandedDebug'
-  def testTaskName = "test${variantName.capitalize()}UnitTest"
+  def testType = "${variantName.capitalize()}UnitTest"
+  def testTaskName = "test${testType}"
 
-  tasks.create(name: "${variantName}Coverage", type: JacocoReport, dependsOn: testTaskName) {
+  tasks.create(name: "make${testType}CoverageReport", type: JacocoReport, dependsOn: testTaskName) {
     group = 'Reporting'
-    description = "Generate Jacoco coverage reports for the ${variantName} build."
+    description = "Generate Jacoco coverage report for the ${variantName} build."
+    onlyIf = { true }
 
     reports {
       html.enabled(true)
@@ -31,7 +29,6 @@ project.afterEvaluate {
       'android/**/*.*',
       'androidx/**/*.*',
       '**/*$ViewInjector*.*',
-      '**/*Dagger*.*',
       '**/*MembersInjector*.*',
       '**/*_Factory.*',
       '**/*_Provide*Factory*.*',
@@ -44,10 +41,11 @@ project.afterEvaluate {
       '**/*Binding.*'
     ]
 
-    def javaClasses = fileTree(dir: "${project.buildDir}/intermediates/javac/${variantName}/classes", excludes: excludes)
-    classDirectories.from = files([javaClasses])
-    sourceDirectories.from = files(["${project.projectDir}/src/main/java"])
-
-    executionData.from = files(["${project.buildDir}/jacoco/${testTaskName}.exec"])
+    classDirectories.from = files([fileTree(
+      dir: "${project.buildDir}/intermediates/javac/${variantName}/classes",
+      excludes: excludes
+    )])
+    sourceDirectories.from = file("${project.projectDir}/src/main/java")
+    executionData.from = file("${project.buildDir}/outputs/unit_test_code_coverage/${testType}/${testTaskName}.exec")
   }
 }


### PR DESCRIPTION
# Description
This PR adds the configuration to generate  test coverage reports for `unbrandedDebug` flavor

Run
`make test-coverage`

See the generated report in:
`build/reports/jacoco/makeUnbrandedDebugUnitTestCoverageReport/html/index.html`

[CHT-Docs PR](https://github.com/medic/cht-docs/pull/640)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.