### PR TITLE
94 - Removing "_redirect" from app root url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ uninstall-all:
 	${GRADLE} uninstallAll
 
 url-tester:
-	DISABLE_APP_URL_VALIDATION=true ${GRADLE} ${GRADLE_OPTS} install${flavor}Debug
+	${GRADLE} ${GRADLE_OPTS} install${flavor}Debug
 
 uninstall:
 	adb uninstall org.medicmobile.webapp.mobile
@@ -97,7 +97,7 @@ test-ui-gamma:
 	${GRADLE} connectedMedicmobilegammaDebugAndroidTest -Pabi=${abi} --stacktrace
 
 test-ui-url:
-	DISABLE_APP_URL_VALIDATION=true ${GRADLE} connectedUnbrandedDebugAndroidTest \
+	${GRADLE} connectedUnbrandedDebugAndroidTest \
 		-Pabi=${abi} --stacktrace -Pandroid.testInstrumentationRunnerArguments.class=\
 	org.medicmobile.webapp.mobile.LastUrlTest
 

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,6 @@ bundle-all: check-env
 uninstall-all:
 	${GRADLE} uninstallAll
 
-url-tester:
-	${GRADLE} ${GRADLE_OPTS} install${flavor}Debug
-
 uninstall:
 	adb uninstall org.medicmobile.webapp.mobile
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,6 @@ android {
   }
 
   applicationVariants.all { variant ->
-    buildConfigField "boolean", "DISABLE_APP_URL_VALIDATION", "Boolean.parseBoolean(\"${System.env.DISABLE_APP_URL_VALIDATION}\")"
     buildConfigField "String",  "LOG_TAG", '"MedicMobile"'
     buildConfigField "Long",    "TTL_LAST_URL", '24l * 60 * 60 * 1000'  // 24 hs max time last URL loaded is remembered
 

--- a/src/main/java/org/medicmobile/webapp/mobile/AppUrlVerifier.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/AppUrlVerifier.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import org.json.JSONException;
 import org.json.JSONObject;
-import static org.medicmobile.webapp.mobile.BuildConfig.DISABLE_APP_URL_VALIDATION;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
 import static org.medicmobile.webapp.mobile.R.string.errAppUrl_apiNotReady;
 import static org.medicmobile.webapp.mobile.R.string.errAppUrl_appNotFound;
@@ -29,30 +28,28 @@ public class AppUrlVerifier {
 	 */
 	public AppUrlVerification verify(String appUrl) {
 		appUrl = clean(appUrl);
-		if(DISABLE_APP_URL_VALIDATION) {
-			return AppUrlVerification.ok(appUrl);
-		}
 
 		try {
 			JSONObject json = jsonClient.get(appUrl + "/setup/poll");
 
-			if(!json.getString("handler").equals("medic-api"))
+			if (!json.getString("handler").equals("medic-api")) {
 				return AppUrlVerification.failure(appUrl, errAppUrl_appNotFound);
-			if(!json.getBoolean("ready"))
+			}
+
+			if (!json.getBoolean("ready")) {
 				return AppUrlVerification.failure(appUrl, errAppUrl_apiNotReady);
+			}
 
 			return AppUrlVerification.ok(appUrl);
+
 		} catch(MalformedURLException ex) {
 			// seems unlikely, as we should have verified this already
-			return AppUrlVerification.failure(appUrl,
-					errInvalidUrl);
+			return AppUrlVerification.failure(appUrl, errInvalidUrl);
 		} catch(JSONException ex) {
-			return AppUrlVerification.failure(appUrl,
-					errAppUrl_appNotFound);
+			return AppUrlVerification.failure(appUrl, errAppUrl_appNotFound);
 		} catch(IOException ex) {
 			trace(ex, "Exception caught trying to verify url: %s", redactUrl(appUrl));
-			return AppUrlVerification.failure(appUrl,
-					errAppUrl_serverNotFound);
+			return AppUrlVerification.failure(appUrl, errAppUrl_serverNotFound);
 		}
 	}
 

--- a/src/main/java/org/medicmobile/webapp/mobile/SettingsStore.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/SettingsStore.java
@@ -7,7 +7,6 @@ import java.util.*;
 import java.util.regex.*;
 
 import static org.medicmobile.webapp.mobile.BuildConfig.DEBUG;
-import static org.medicmobile.webapp.mobile.BuildConfig.DISABLE_APP_URL_VALIDATION;
 import static org.medicmobile.webapp.mobile.BuildConfig.TTL_LAST_URL;
 import static org.medicmobile.webapp.mobile.SimpleJsonClient2.redactUrl;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
@@ -22,17 +21,12 @@ public abstract class SettingsStore {
 
 	public abstract String getAppUrl();
 
-	public String getRootUrl() {
-		String appUrl = getAppUrl();
-		return appUrl + (DISABLE_APP_URL_VALIDATION ? "" : "/medic/_design/medic/_rewrite/");
-	}
-
 	public String getUrlToLoad(Uri url) {
-		return url != null ? url.toString() : getRootUrl();
+		return url != null ? url.toString() : getAppUrl();
 	}
 
 	public boolean isRootUrl(String url) {
-		return getRootUrl().equals(url);
+		return getAppUrl().equals(url);
 	}
 
 	public abstract boolean hasWebappSettings();

--- a/src/test/java/org/medicmobile/webapp/mobile/SettingsStoreTest.java
+++ b/src/test/java/org/medicmobile/webapp/mobile/SettingsStoreTest.java
@@ -25,7 +25,7 @@ public class SettingsStoreTest {
 
 	SharedPreferences sharedPreferences;
 	SettingsStore settingsStore;
-	static String APP_URL = "https://project-abc.medic.org";
+	static final String APP_URL = "https://project-abc.medic.org";
 
 	@Before
 	public void setup() {

--- a/src/test/java/org/medicmobile/webapp/mobile/SettingsStoreTest.java
+++ b/src/test/java/org/medicmobile/webapp/mobile/SettingsStoreTest.java
@@ -23,9 +23,9 @@ import org.robolectric.annotation.Config;
 @Config(sdk=28)
 public class SettingsStoreTest {
 
-	SharedPreferences sharedPreferences;
-	SettingsStore settingsStore;
-	static final String APP_URL = "https://project-abc.medic.org";
+	private SharedPreferences sharedPreferences;
+	private SettingsStore settingsStore;
+	private static final String APP_URL = "https://project-abc.medic.org";
 
 	@Before
 	public void setup() {

--- a/src/test/java/org/medicmobile/webapp/mobile/SettingsStoreTest.java
+++ b/src/test/java/org/medicmobile/webapp/mobile/SettingsStoreTest.java
@@ -1,0 +1,244 @@
+package org.medicmobile.webapp.mobile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.SharedPreferences;
+import android.net.Uri;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk=28)
+public class SettingsStoreTest {
+
+	public SettingsStore setup(String appUrl, SharedPreferences sharedPreferences) {
+		return new SettingsStore(sharedPreferences) {
+			@Override
+			public String getAppUrl() {
+				return appUrl;
+			}
+
+			@Override
+			public boolean hasWebappSettings() {
+				return false;
+			}
+
+			@Override
+			public boolean allowsConfiguration() {
+				return false;
+			}
+
+			@Override
+			public void update(SharedPreferences.Editor ed, WebappSettings s) {
+
+			}
+		};
+	}
+
+	@Test
+	public void getAppUrl_withUrlSet_returnsUrlString() {
+		//> GIVEN
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", null);
+
+		//> WHEN
+		String expected = settingsStore.getAppUrl();
+
+		//> THEN
+		assertEquals("https://project-abc.medic.org", expected);
+	}
+
+	@Test
+	public void getAppUrl_withNullUrl_returnsNull() {
+		//> GIVEN
+		SettingsStore settingsStore = setup(null, null);
+
+		//> WHEN
+		String expected = settingsStore.getAppUrl();
+
+		//> THEN
+		assertNull(expected);
+	}
+
+	@Test
+	public void getUrlToLoad_withValidUrl_returnsUrlString() {
+		//> GIVEN
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", null);
+		Uri uri = Uri.parse("https://project-zxy.medic.org");
+
+		//> WHEN
+		String expected = settingsStore.getUrlToLoad(uri);
+
+		//> THEN
+		assertEquals("https://project-zxy.medic.org", expected);
+	}
+
+	@Test
+	public void getUrlToLoad_withInvalidUrl_returnsAppUrlString() {
+		//> GIVEN
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", null);
+
+		//> WHEN
+		String expected = settingsStore.getUrlToLoad(null);
+
+		//> THEN
+		assertEquals("https://project-abc.medic.org", expected);
+	}
+
+	@Test
+	public void isRootUrl_withAppUrl_returnsTrue() {
+		//> GIVEN
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", null);
+
+		//> WHEN
+		boolean expected = settingsStore.isRootUrl("https://project-abc.medic.org");
+
+		//> THEN
+		assertTrue(expected);
+	}
+
+	@Test
+	public void isRootUrl_withOtherUrl_returnsFalse() {
+		//> GIVEN
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", null);
+
+		//> WHEN
+		boolean expected = settingsStore.isRootUrl("https://project.health-ministry.org");
+
+		//> THEN
+		assertFalse(expected);
+	}
+
+	@Test
+	public void isRootUrl_withNullUrl_returnsFalse() {
+		//> GIVEN
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", null);
+
+		//> WHEN
+		boolean expected = settingsStore.isRootUrl(null);
+
+		//> THEN
+		assertFalse(expected);
+	}
+
+	@Test
+	public void get_withPrefSet_returnsValue() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getString("a_setting", null)).thenReturn("a_value");
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		String expected = settingsStore.get("a_setting");
+
+		//> THEN
+		assertEquals("a_value", expected);
+	}
+
+	@Test
+	public void get_withNoPrefSet_returnsNull() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getString("a_setting", null)).thenReturn(null);
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		String expected = settingsStore.get("a_setting");
+
+		//> THEN
+		assertNull(expected);
+	}
+
+	@Test
+	public void getUnlockCode_withPrefSet_returnsValue() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getString("unlock-code", null)).thenReturn("a_value");
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		String expected = settingsStore.get("unlock-code");
+
+		//> THEN
+		assertEquals("a_value", expected);
+	}
+
+	@Test
+	public void getUnlockCode_withNoPrefSet_returnsNull() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getString("unlock-code", null)).thenReturn(null);
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		String expected = settingsStore.get("unlock-code");
+
+		//> THEN
+		assertNull(expected);
+	}
+
+	@Test
+	public void hasUserDeniedGeolocation_withPrefSet_returnsValue() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getBoolean("denied-geolocation", false)).thenReturn(true);
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		boolean expected = settingsStore.hasUserDeniedGeolocation();
+
+		//> THEN
+		assertTrue(expected);
+	}
+
+	@Test
+	public void getUnlockCode_withNoPrefSet_returnsFalse() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getBoolean("denied-geolocation", false)).thenReturn(true);
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		boolean expected = settingsStore.hasUserDeniedGeolocation();
+
+		//> THEN
+		assertTrue(expected);
+	}
+
+	@Test
+	public void getLastUrl_withLastUrlTime_returnsLastUrl() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getLong("last-url-time-ms", 0)).thenReturn(System.currentTimeMillis());
+		when(sharedPreferences.getString("last-url", null)).thenReturn("https://project-abc.medic.org/#messages");
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		String expected = settingsStore.getLastUrl();
+
+		//> THEN
+		assertEquals("https://project-abc.medic.org/#messages", expected);
+	}
+
+	@Test
+	public void getLastUrl_withTooOldLastUrlTime_returnsNull() {
+		//> GIVEN
+		SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+		when(sharedPreferences.getLong("last-url-time-ms", 0)).thenReturn(60L);
+		when(sharedPreferences.getString("last-url", null)).thenReturn("https://project-abc.medic.org/#messages");
+		SettingsStore settingsStore = setup("https://project-abc.medic.org", sharedPreferences);
+
+		//> WHEN
+		String expected = settingsStore.getLastUrl();
+
+		//> THEN
+		assertNull(expected);
+	}
+}


### PR DESCRIPTION
# Description 

This PR:

- Removes `DISABLE_APP_URL_VALIDATION` and therefore the App URL verification (AppUrlVerification class) isn't skipped anymore. 
- Stops appending `/medic/_design/medic/_rewrite/` to the App URL. 
- Adds some unit test coverage

Ticket: https://github.com/medic/cht-android/issues/94

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.