### PR TITLE
Update pmd gradle config to exclude files and add support for xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,13 @@ task pmd(type: Pmd) {
   ruleSets = []
   ignoreFailures = false
   source 'src'
+  exclude '**/**.png'
+  exclude '**/**.mp3'
+  exclude '**/**.bats'
+  dependencies {
+    pmd 'net.sourceforge.pmd:pmd-java:6.36.0'
+    pmd 'net.sourceforge.pmd:pmd-xml:6.36.0'
+  }
 }
 
 spotbugs {


### PR DESCRIPTION
Updates Gradle config for the PMD task so that `XML` files can be parsed.  Also excludes `png/mp3/bats` files since those also cannot be parsed by PMD.  

See https://github.com/gradle/gradle/issues/5451 for more info on why adding the `pmd-xml` dependency enables support for xml files...

Also, for the record here is the changes that happen to the dependency tree as a result of this change:

<table>
<tr>
	<td>master
	<td>255_pmd_config
<tr>
	<td>
<pre>
pmd - The PMD libraries to be used for this project.
\--- net.sourceforge.pmd:pmd-java:6.36.0
     +--- net.sourceforge.pmd:pmd-core:6.36.0
     |    +--- org.antlr:antlr4-runtime:4.7.2
     |    +--- com.beust:jcommander:1.48
     |    +--- commons-io:commons-io:2.6
     |    +--- net.sourceforge.saxon:saxon:9.1.0.8
     |    +--- org.apache.commons:commons-lang3:3.8.1
     |    +--- org.ow2.asm:asm:9.1
     |    \--- com.google.code.gson:gson:2.8.5
     +--- net.sourceforge.saxon:saxon:9.1.0.8
     +--- org.ow2.asm:asm:9.1
     +--- commons-io:commons-io:2.6
     \--- org.apache.commons:commons-lang3:3.8.1
</pre>
	</td>
	<td>
<pre>
pmd - The PMD libraries to be used for this project.
+--- net.sourceforge.pmd:pmd-java:6.36.0
|    +--- net.sourceforge.pmd:pmd-core:6.36.0
|    |    +--- org.antlr:antlr4-runtime:4.7.2
|    |    +--- com.beust:jcommander:1.48
|    |    +--- commons-io:commons-io:2.6
|    |    +--- net.sourceforge.saxon:saxon:9.1.0.8
|    |    +--- org.apache.commons:commons-lang3:3.8.1
|    |    +--- org.ow2.asm:asm:9.1
|    |    \--- com.google.code.gson:gson:2.8.5
|    +--- net.sourceforge.saxon:saxon:9.1.0.8
|    +--- org.ow2.asm:asm:9.1
|    +--- commons-io:commons-io:2.6
|    \--- org.apache.commons:commons-lang3:3.8.1
\--- net.sourceforge.pmd:pmd-xml:6.36.0
     +--- net.sourceforge.pmd:pmd-core:6.36.0 (*)
     +--- org.antlr:antlr4-runtime:4.7.2
     \--- commons-io:commons-io:2.6
</pre>
	</td>
</table>

Closes #255 