### PR TITLE
258 - Differentiate training app

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,11 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "medicmobilegamma" }'
+    - name: Assemble gamma training
+      uses: maierj/fastlane-action@v1.4.0
+      with:
+        lane: build
+        options: '{ "flavor": "medicmobilegamma_training" }'
     # demo app is disabled for now
     #- name: Assemble demo
     #  uses: maierj/fastlane-action@v1.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,8 @@ android {
     buildConfigField "String", "TEST_USERNAME", "\"${System.env.ANDROID_TEST_USERNAME}\""
     buildConfigField "String", "TEST_PASSWORD", "\"${System.env.ANDROID_TEST_PASSWORD}\""
 
+    buildConfigField "boolean", "IS_TRAINING_APP", 'false'
+
     if (System.env.ANDROID_TEST_URL) {
       buildConfigField "String", "SERVER_URL", "\"${System.env.ANDROID_TEST_URL}\""
     } else {
@@ -205,6 +207,12 @@ android {
     medicmobilegamma {
       dimension = 'brand'
       applicationId = 'org.medicmobile.webapp.mobile.medicmobilegamma'
+    }
+
+    medicmobilegamma_training {
+      dimension = 'brand'
+      applicationId = 'org.medicmobile.webapp.mobile.medicmobilegamma_training'
+      buildConfigField "boolean", "IS_TRAINING_APP", 'true'
     }
 
     bracuganda {

--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -92,6 +92,13 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 			webviewContainer.setBackgroundColor(R.drawable.warning_background);
 		}
 
+		// Add a noticeable border to easily identify a training app
+		if (BuildConfig.IS_TRAINING_APP) {
+			View webviewContainer = findViewById(R.id.lytWebView);
+			webviewContainer.setPadding(10, 10, 10, 10);
+			webviewContainer.setBackgroundResource(R.drawable.training_background);
+		}
+
 		container = findViewById(R.id.wbvMain);
 
 		configureUserAgent();
@@ -135,6 +142,11 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 			trace(this, "onStart() :: Crosswalk installation not found - skipping migration");
 		}
 		trace(this, "onStart() :: Checking Crosswalk migration done.");
+
+		if (BuildConfig.IS_TRAINING_APP) {
+			toast(getString(R.string.usingTrainingApp));
+		}
+
 		super.onStart();
 	}
 

--- a/src/main/res/drawable/training_background.xml
+++ b/src/main/res/drawable/training_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+		android:shape="rectangle">
+	<solid android:color="#ffa500"/>
+	<corners android:radius="10px"/>
+</shape>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -28,4 +28,5 @@
 	<string name="connErrorMessage">Vous n\'êtes pas bien connecté à internet. Veuillez vérifier votre connexion et réessayer.</string>
 
 	<string name="waitMigration">Veuillez attendre que la migration de données termine</string>
+  <string name="usingTrainingApp">Utiliser uniquement pendant la formation</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -65,4 +65,5 @@
 	<string name="connErrorMessage">You don\'t seem to be connected to the Internet. Please check your connection and try again.</string>
 
 	<string name="waitMigration">Please wait until the migration process is finished</string>
+  <string name="usingTrainingApp">Use only during training</string>
 </resources>

--- a/src/medicmobilegamma_training/res/values/strings.xml
+++ b/src/medicmobilegamma_training/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">[TRAINING] Medic (gamma)</string>
+	<string name="app_host">gamma.dev.medicmobile.org</string>
+</resources>


### PR DESCRIPTION
Adds border and training app message

For https://github.com/medic/cht-android/issues/258

This will be useful for new deployments that want to differentiate their Training app, and would NOT affect any existing flavors.

[_**Update**:_ documentation in [cht-docs/678](https://github.com/medic/cht-docs/pull/678)]