### PR TITLE
257 - Remove unbranded test flavor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,11 +192,6 @@ jobs:
       with:
         lane: build
         options: '{ "flavor": "trippleeighty" }'
-    - name: Assemble unbranded_test
-      uses: maierj/fastlane-action@v1.4.0
-      with:
-        lane: build
-        options: '{ "flavor": "unbranded_test" }'
     - name: Assemble vhw_burundi
       uses: maierj/fastlane-action@v1.4.0
       with:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Checkout the release notes in the [Changelog](CHANGELOG.md) page, our you can se
 Development guides are available in the "Android" section of the [Community Health Toolkit Docs Site](https://docs.communityhealthtoolkit.org/core/guides/android/). You will find instructions of how to setup your development environment, build and test new features, creates new branded apps, release, publish... and so on.
 
 
+## Settings Dialog
+To open the Settings Dialog page, tap 5 times with one finger on the screen and then swipe right with two fingers, make sure to do this sequence fast.
+
 ## Copyright
 
 Copyright 2013-2022 Medic Mobile, Inc. <hello@medic.org>.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Checkout the release notes in the [Changelog](CHANGELOG.md) page, our you can se
 Development guides are available in the "Android" section of the [Community Health Toolkit Docs Site](https://docs.communityhealthtoolkit.org/core/guides/android/). You will find instructions of how to setup your development environment, build and test new features, creates new branded apps, release, publish... and so on.
 
 
-## Settings Dialog
-To open the Settings Dialog page, tap 5 times with one finger on the screen and then swipe right with two fingers, make sure to do this sequence fast.
-
 ## Copyright
 
 Copyright 2013-2022 Medic Mobile, Inc. <hello@medic.org>.

--- a/build.gradle
+++ b/build.gradle
@@ -342,11 +342,6 @@ android {
       applicationId = "org.medicmobile.webapp.mobile.vhtapp_uganda"
     }
 
-    unbranded_test {
-      dimension = 'brand'
-      applicationId = "org.medicmobile.webapp.mobile.unbranded_test"
-    }
-
     itech_aurum {
       dimension = 'brand'
       applicationId = 'org.medicmobile.webapp.mobile.itech_aurum'

--- a/src/unbranded_test/AndroidManifest.xml
+++ b/src/unbranded_test/AndroidManifest.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.medicmobile.webapp.mobile">
-
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove" />
-
-</manifest>


### PR DESCRIPTION
# Description

This PR: 
- Removes the `unbranded_test` flavor. If we need to test a flavor without any of the permissions, then we can do that locally without adding a new flavor in the source code.

Note: Partners will need to add the permission by themselves, so they can control when to release it and when communicate the change to their CHWs. A partner might want to add a permission if they are using a feature that requires it. Because of that, we won't update any of the partners' flavor.

Ticket: https://github.com/medic/cht-android/issues/257

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.