### PR TITLE
Remove duplicate switch case that was accidentally added

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -208,9 +208,6 @@ public class EmbeddedBrowserActivity extends Activity {
 				case ACCESS_SEND_SMS_PERMISSION:
 					this.smsSender.resumeProcess(resultCode);
 					return;
-				case ACCESS_SEND_SMS_PERMISSION:
-					this.smsSender.resumeProcess(resultCode);
-					return;
 				default:
 					trace(this, "onActivityResult() :: no handling for requestCode=%s", requestCode.name());
 			}


### PR DESCRIPTION
Thanks to some poor git merging magic, we ended up with a duplicate `switch` case that needs to be removed.