### PR TITLE
commenting SEND_SMS permission

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -19,11 +19,12 @@
   <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
   <uses-permission android:name="com.android.launcher.permission.UNINSTALL_SHORTCUT"/>
 
-  <!-- READ_EXTERNAL_STORAGE required if users want to include photos from their phone  -->
+  <!-- READ_EXTERNAL_STORAGE is required if users want to include photos from their phone  -->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
-  <!-- SEND_SMS required if users want to send reports as SMS -->
+  <!-- SEND_SMS is required if users want to send reports as SMS.To able the feature add the following line:
   <uses-permission android:name="android.permission.SEND_SMS"/>
+  -->
 
   <application android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
# Description

Projects should add this permission if they want to send forms as sms. 
When publishing in Play Store, projects needs to justify why they need the permission 