### PR TITLE
287 - Allow installing multiple flavors in the same device

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,7 @@ android {
       // src/main
       dimension = 'brand'
       buildConfigField "boolean", "IS_TRAINING_APP", 'true'
+      applicationId = 'org.medicmobile.webapp.mobile'
     }
 
     medicmobiledemo {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
 
     <provider
       android:name="androidx.core.content.FileProvider"
-      android:authorities="org.medicmobile.webapp.mobile.fileprovider"
+      android:authorities="${applicationId}.fileprovider"
       android:exported="false"
       android:grantUriPermissions="true">
       <meta-data


### PR DESCRIPTION
# Description

This PR
- Adds `applicationId` to `unbranded` flavor, so every flavor keeps defining this property and ensure there aren't conflicts by having default values. Consistency. 
- Uses `applicationId` to define provider in manifest.

Ticket: https://github.com/medic/cht-android/issues/287


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.