### PR TITLE
fix(#319): launch proper server from filtered server list

### DIFF
--- a/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
+++ b/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
@@ -160,7 +160,7 @@ public class SettingsDialogActivityTest {
 	}
 
 	@Test
-	public void testFilterServers() {
+	public void testFilterServers() throws InterruptedException {
 		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));
 		onView(withText("Custom")).check(matches(isDisplayed()));
 		onView(withText(SERVER_ONE)).check(matches(isDisplayed()));
@@ -170,6 +170,7 @@ public class SettingsDialogActivityTest {
 		ViewInteraction textFilter = onView(withId(R.id.instanceSearchBox));
 		textFilter.check(matches(withHint("Search Instances")));
 		textFilter.perform(replaceText("github"), closeSoftKeyboard());
+		Thread.sleep(500);
 
 		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));
 		onView(withText("Custom")).check(doesNotExist());
@@ -178,6 +179,7 @@ public class SettingsDialogActivityTest {
 		onView(withText(SERVER_THREE)).check(doesNotExist());
 
 		textFilter.perform(replaceText(""), closeSoftKeyboard());
+		Thread.sleep(500);
 
 		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));
 		onView(withText("Custom")).check(matches(isDisplayed()));
@@ -186,6 +188,7 @@ public class SettingsDialogActivityTest {
 		onView(withText(SERVER_THREE)).check(matches(isDisplayed()));
 
 		textFilter.perform(replaceText("gamma"), closeSoftKeyboard());
+		Thread.sleep(500);
 
 		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));
 		onView(withText("Custom")).check(doesNotExist());

--- a/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
+++ b/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
@@ -184,6 +184,23 @@ public class SettingsDialogActivityTest {
 		onView(withText(SERVER_ONE)).check(matches(isDisplayed()));
 		onView(withText(SERVER_TWO)).check(matches(isDisplayed()));
 		onView(withText(SERVER_THREE)).check(matches(isDisplayed()));
+
+		textFilter.perform(replaceText("gamma"), closeSoftKeyboard());
+
+		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));
+		onView(withText("Custom")).check(doesNotExist());
+		onView(withText(SERVER_ONE)).check(doesNotExist());
+		onView(withText(SERVER_TWO)).check(matches(isDisplayed()));
+		onView(withText(SERVER_THREE)).check(matches(isDisplayed()));
+
+		onData(anything())
+			.inAdapterView(withId(R.id.lstServers))
+			.atPosition(0)
+			.perform(click());
+
+		onView(withText("Login to Gamma Dev?"))
+			.inRoot(isDialog())
+			.check(matches(isDisplayed()));
 	}
 
 	private String getLanguage(String code) {

--- a/src/main/java/org/medicmobile/webapp/mobile/SettingsDialogActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/SettingsDialogActivity.java
@@ -65,7 +65,7 @@ public class SettingsDialogActivity extends FragmentActivity {
 		List<ServerMetadata> servers = serverRepo.getServers();
 		ServerMetadataAdapter adapter = ServerMetadataAdapter.createInstance(this, servers);
 		list.setAdapter(adapter);
-		list.setOnItemClickListener(new ServerClickListener(servers));
+		list.setOnItemClickListener(new ServerClickListener(adapter));
 
 		TextView seachBox = findViewById(R.id.instanceSearchBox);
 		seachBox.addTextChangedListener(new TextChangedListener() {
@@ -186,19 +186,20 @@ public class SettingsDialogActivity extends FragmentActivity {
 
 //> INNER CLASSES
 	class ServerClickListener implements OnItemClickListener {
-		private final List<ServerMetadata> servers;
+		private final ServerMetadataAdapter serverMetadataAdapter;
 
-		public ServerClickListener(List<ServerMetadata> servers) {
-			this.servers = servers;
+		public ServerClickListener(ServerMetadataAdapter serverMetadataAdapter) {
+			this.serverMetadataAdapter = serverMetadataAdapter;
 		}
 
 		public void onItemClick(AdapterView<?> parent, final View view, int position, long id) {
-			if (settings.allowCustomHosts() && position == 0) {
+			ServerMetadata server = serverMetadataAdapter.getServerMetadata(position);
+			if (server.url == null) {
 				displayCustomServerForm();
 			} else {
 				new ConfirmServerSelectionDialog(
-					servers.get(position).name,
-					() -> saveSettings(new WebappSettings(servers.get(position).url))
+					server.name,
+					() -> saveSettings(new WebappSettings(server.url))
 				).show(getSupportFragmentManager());
 			}
 		}
@@ -218,6 +219,12 @@ public class SettingsDialogActivity extends FragmentActivity {
 
 		static ServerMetadataAdapter createInstance(Context context, List<ServerMetadata> servers) {
 			return new ServerMetadataAdapter(context, adapt(servers));
+		}
+
+		@SuppressWarnings("unchecked")
+		ServerMetadata getServerMetadata(int position) {
+			Map<String, String> dataMap = (Map<String, String>) this.getItem(position);
+			return new ServerMetadata(dataMap.get("name"), dataMap.get("url"));
 		}
 
 		private static List<Map<String, ?>> adapt(List<ServerMetadata> servers) {


### PR DESCRIPTION
Closes #319 

## Testing considerations

These changes affect the logic that determines which servers are launched when an item is selected in the server list.  We need to check that the expected server is launched.  The custom URL logic should also be tested to ensure the custom URL page is launched only when expected.  

## Apks
[unbranded.zip](https://github.com/medic/cht-android/files/11709631/unbranded.zip)
[Uploading moh_kenya_echis.zip…]()

