### PR TITLE
fix(#345): Hardcode the values `ANDROID_KEY_ALIAS` and `ANDROID_KEYSTORE_PATH` in make command `check-env`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,8 @@ ifndef ANDROID_SECRETS_IV
 	$(eval ANDROID_KEYSTORE_PASSWORD := $(shell echo ${${VARNAME}}))
 	$(eval VARNAME=ANDROID_KEY_PASSWORD_${ORG_UPPER})
 	$(eval ANDROID_KEY_PASSWORD := $(shell echo ${${VARNAME}}))
-	$(eval VARNAME=ANDROID_KEY_ALIAS_${ORG_UPPER})
-	$(eval ANDROID_KEY_ALIAS := $(shell echo ${${VARNAME}}))
-	$(eval VARNAME=ANDROID_KEYSTORE_PATH_${ORG_UPPER})
-	$(eval ANDROID_KEYSTORE_PATH := $(shell echo ${${VARNAME}}))
+	$(eval ANDROID_KEY_ALIAS := "medicmobile")
+	$(eval ANDROID_KEYSTORE_PATH := "${org}.keystore")
 endif
 
 check-keystore-exist:
@@ -216,8 +214,6 @@ secrets/secrets-${org}.tar.gz.enc: secrets/secrets-${org}.tar.gz
 	$(info export ANDROID_KEY_PASSWORD_$(ORG_UPPER)=$(ANDROID_KEYSTORE_PASSWORD))
 	$(info export ANDROID_SECRETS_IV_$(ORG_UPPER)=$(ANDROID_SECRETS_IV))
 	$(info export ANDROID_SECRETS_KEY_$(ORG_UPPER)=$(ANDROID_SECRETS_KEY))
-	$(info export ANDROID_KEYSTORE_PATH_$(ORG_UPPER)=$(ANDROID_KEYSTORE_PATH))
-	$(info export ANDROID_KEY_ALIAS_$(ORG_UPPER)=$(ANDROID_KEY_ALIAS))
 	$(info )
 	$(info #)
 	$(info # The file secrets/secrets-${org}.tar.gz.enc was created and has to be added to the git)

--- a/src/test/bash/test-keystore.bats
+++ b/src/test/bash/test-keystore.bats
@@ -88,8 +88,6 @@ teardown() {
   export ANDROID_KEY_PASSWORD_TEST="abc"
   export ANDROID_SECRETS_IV_TEST="1234abc"
   export ANDROID_SECRETS_KEY_TEST="111222"
-  export ANDROID_KEYSTORE_PATH_TEST="test.keystore"
-  export ANDROID_KEY_ALIAS_TEST="medicmobile"
   # Now trying to decrypt without the right env sets fails
   run make org=test keydec
   assert_failure 2
@@ -104,8 +102,6 @@ teardown() {
   export ANDROID_KEY_PASSWORD_TEST=$(echo "$out" | grep ANDROID_KEY_PASSWORD_TEST | awk 'BEGIN { FS="=" } {print $2}')
   export ANDROID_SECRETS_IV_TEST=$(echo "$out" | grep ANDROID_SECRETS_IV_TEST | awk 'BEGIN { FS="=" } {print $2}')
   export ANDROID_SECRETS_KEY_TEST=$(echo "$out" | grep ANDROID_SECRETS_KEY_TEST | awk 'BEGIN { FS="=" } {print $2}')
-  export ANDROID_KEYSTORE_PATH_TEST=$(echo "$out" | grep ANDROID_KEYSTORE_PATH_TEST | awk 'BEGIN { FS="=" } {print $2}')
-  export ANDROID_KEY_ALIAS_TEST=$(echo "$out" | grep ANDROID_KEY_ALIAS_TEST | awk 'BEGIN { FS="=" } {print $2}')
   # Removed the unencrypted files
   make RM_KEY_OPTS="-f" org=test keyrm
   # Now decrypt from the encrypted version (.tar.gz.enc file)


### PR DESCRIPTION
The changes include hardcoding the values `ANDROID_KEY_ALIAS` AND `ANDROID_KEYSTORE_PATH` in the `make` command `check-env` such that they don't use the secrets in the repository.

Fixes: (#345 )