### PR TITLE
chore: add missing changelog entry for 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 
 # Release notes
 
+## 1.2.0
+
+### Improvements
+
+* Support Android 14 ([#349](https://github.com/medic/cht-android/pull/349))
+
+### Flavors
+
+* Add apk for cares malawi ([#334](https://github.com/medic/cht-android/pull/334))
+* Generate Moh Togo UAT app bundle ([#339](https://github.com/medic/cht-android/pull/339))
+
+### Technical Improvements
+
+* Upgrade ruby version for fastlane ([#341](https://github.com/medic/cht-android/pull/341))
+* Updated keystores for CARES APKs ([#342](https://github.com/medic/cht-android/pull/342))
+* Fix e2e tests on CI ([#348](https://github.com/medic/cht-android/pull/348))
+* Hardcode the values `ANDROID_KEY_ALIAS` and `ANDROID_KEYSTORE_PATH` in make command `check-env` ([#347](https://github.com/medic/cht-android/pull/347))
+
 ## 1.1.0
 
 This release includes the following work:


### PR DESCRIPTION
Forgot to update the CHANGELOG before cutting the release!

https://github.com/medic/cht-android/releases/tag/v1.2.0