### PR TITLE
chore: Add missing changelog entry for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 # Release notes
 
+## 1.3.0
+
+* Add sonar configuration ([#352](https://github.com/medic/cht-android/pull/352))
+* Add autoverify=true to AndroidManifest.xml file ([#353](https://github.com/medic/cht-android/pull/353))
+* Add prominent disclosure on startup requesting user to link app and domain ([#353](https://github.com/medic/cht-android/pull/354))
+
 ## 1.2.0
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@
 
 ## 1.3.0
 
-* Add sonar configuration ([#352](https://github.com/medic/cht-android/pull/352))
+### Improvements
+
 * Add autoverify=true to AndroidManifest.xml file ([#353](https://github.com/medic/cht-android/pull/353))
 * Add prominent disclosure on startup requesting user to link app and domain ([#353](https://github.com/medic/cht-android/pull/354))
+
+### Technical Improvements
+
+* Add sonar configuration ([#352](https://github.com/medic/cht-android/pull/352))
 
 ## 1.2.0
 


### PR DESCRIPTION
Forgot to update the CHANGELOG before cutting the release!

https://github.com/medic/cht-android/releases/tag/v1.3.0