### PR TITLE
fix(#338): Refactor OpenSettingsDialogFragment class to have a empty constructor

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -102,7 +102,7 @@ public class EmbeddedBrowserActivity extends Activity {
 		container = findViewById(R.id.wbvMain);
 		getFragmentManager()
 			.beginTransaction()
-			.add(new OpenSettingsDialogFragment(container), OpenSettingsDialogFragment.class.getName())
+			.add(new OpenSettingsDialogFragment(), OpenSettingsDialogFragment.class.getName())
 			.commit();
 
 		configureUserAgent();

--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -13,14 +13,15 @@ import androidx.annotation.Nullable;
 
 import java.time.Clock;
 
-@SuppressLint("ValidFragment")
 public class OpenSettingsDialogFragment extends Fragment {
 
-	private final View view;
 	private int fingerTapCount = 0;
 	private long lastTimeTap = 0;
 	private GestureHandler swipeGesture;
 	private static final int TIME_BETWEEN_TAPS = 500;
+
+	public OpenSettingsDialogFragment() {
+	}
 
 	private final OnTouchListener onTouchListener = new OnTouchListener() {
 		@SuppressLint("ClickableViewAccessibility")
@@ -32,13 +33,10 @@ public class OpenSettingsDialogFragment extends Fragment {
 		}
 	};
 
-	public OpenSettingsDialogFragment(View view) {
-		this.view = view;
-	}
-
 	@Override
 	public void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		View view = getActivity().findViewById(R.id.wbvMain);
 		view.setOnTouchListener(onTouchListener);
 	}
 

--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -20,9 +20,6 @@ public class OpenSettingsDialogFragment extends Fragment {
 	private GestureHandler swipeGesture;
 	private static final int TIME_BETWEEN_TAPS = 500;
 
-	public OpenSettingsDialogFragment() {
-	}
-
 	private final OnTouchListener onTouchListener = new OnTouchListener() {
 		@SuppressLint("ClickableViewAccessibility")
 		@Override

--- a/src/test/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragmentTest.java
+++ b/src/test/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragmentTest.java
@@ -49,11 +49,12 @@ public class OpenSettingsDialogFragmentTest {
 		doNothing().when(view).setOnTouchListener(argsOnTouch.capture());
 
 		MockSettings fragmentSettings = withSettings()
-			.useConstructor(view)
+			.useConstructor()
 			.defaultAnswer(CALLS_REAL_METHODS);
 
 		openSettingsDialogFragment = mock(OpenSettingsDialogFragment.class, fragmentSettings);
 		when(openSettingsDialogFragment.getActivity()).thenReturn(activity);
+		when(openSettingsDialogFragment.getActivity().findViewById(R.id.wbvMain)).thenReturn(view);
 		argsStartActivity = ArgumentCaptor.forClass(Intent.class);
 		doNothing().when(openSettingsDialogFragment).startActivity(argsStartActivity.capture());
 


### PR DESCRIPTION
Fixes: #338

Refactored the `OpenSettingsDialogFragment` class to have an empty constructor.
According to the Android documentation, every `Fragment` class should have an empty constructor that does nothing and is not a non-empty constructor. [Reference](https://developer.android.com/reference/android/app/Fragment.html#Fragment()). Not doing this leads to the Android ecosystem being unable to restore the Fragment's state when re-instantiated causing the issue mentioned in the linked issue.

Testing:
For e2e testing, you can start using the app normally and ensure that it does not crash and to test the functionality that the `OpenSettingsDialogFragment` class provides, you can tap the screen 5 times and then, right-swipe the screen with 2 fingers.