### PR TITLE
chore(#373): update `actions/upload-artifact` action image to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         script: make test-ui-gamma
 
     - name: Archive Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Test Report
         path: |

--- a/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
+++ b/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
@@ -60,7 +60,7 @@ public class SettingsDialogActivityTest {
 
 	@Test
 	public void serverSelectionScreenIsDisplayed() {
-		onView(withText("CHT Android")).check(matches(isDisplayed()));
+		onView(withText("This does not exist")).check(matches(isDisplayed()));
 		onView(withId(R.id.instanceSearchBox)).check(matches(isDisplayed()));
 		onView(withText("Custom")).check(matches(isDisplayed()));
 		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));

--- a/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
+++ b/src/androidTestUnbrandedDebug/java/org/medicmobile/webapp/mobile/SettingsDialogActivityTest.java
@@ -60,7 +60,7 @@ public class SettingsDialogActivityTest {
 
 	@Test
 	public void serverSelectionScreenIsDisplayed() {
-		onView(withText("This does not exist")).check(matches(isDisplayed()));
+		onView(withText("CHT Android")).check(matches(isDisplayed()));
 		onView(withId(R.id.instanceSearchBox)).check(matches(isDisplayed()));
 		onView(withText("Custom")).check(matches(isDisplayed()));
 		onView(withId(R.id.lstServers)).check(matches(isDisplayed()));


### PR DESCRIPTION
Closes https://github.com/medic/cht-android/issues/373

I reviewed the [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), but our use case is so simple that I do not for-see any changes being necessary.

I confirmed the new version works as expected  by intentionally pushing a commit to this branch that broke a test.  You can see the uploaded artifact here: https://github.com/medic/cht-android/actions/runs/10906781402/artifacts/1943597746