### PR TITLE
fix(#376): fix issue of the app crashing in some phones

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -22,7 +22,7 @@ public class OpenSettingsDialogFragment extends Fragment {
 	private GestureHandler swipeGesture;
 	private static final int TIME_BETWEEN_TAPS = 500;
 	private View mainView;
-	private boolean isViewSetup = false;
+	boolean isViewSetup = false;
 
 	private final OnTouchListener onTouchListener = new OnTouchListener() {
 		@SuppressLint("ClickableViewAccessibility")
@@ -62,13 +62,17 @@ public class OpenSettingsDialogFragment extends Fragment {
 		return false;
 	}
 
-	private void setupViewWithRetry() {
+	void setupViewWithRetry() {
 		new Handler(Looper.getMainLooper()).post(new Runnable() {
 			@Override
 			public void run() {
-				if (shouldSetupView() && !setupView()) {
-					new Handler(Looper.getMainLooper()).postDelayed(this, 100);
+				if (!shouldSetupView() || !setupView()) {
+					retrySetup();
 				}
+			}
+
+			private void retrySetup() {
+				new Handler(Looper.getMainLooper()).postDelayed(this, 100);
 			}
 		});
 	}

--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -5,6 +5,9 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
@@ -19,6 +22,8 @@ public class OpenSettingsDialogFragment extends Fragment {
 	private long lastTimeTap = 0;
 	private GestureHandler swipeGesture;
 	private static final int TIME_BETWEEN_TAPS = 500;
+	private View mainView;
+	private boolean isViewSetup = false;
 
 	private final OnTouchListener onTouchListener = new OnTouchListener() {
 		@SuppressLint("ClickableViewAccessibility")
@@ -33,8 +38,32 @@ public class OpenSettingsDialogFragment extends Fragment {
 	@Override
 	public void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		View view = getActivity().findViewById(R.id.wbvMain);
-		view.setOnTouchListener(onTouchListener);
+		setRetainInstance(true);
+	}
+
+	@Override
+	public void onActivityCreated(Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+		setupViewWithRetry();
+	}
+
+	private void setupViewWithRetry() {
+		new Handler(Looper.getMainLooper()).post(new Runnable() {
+			@Override
+			public void run() {
+				if (getActivity() != null && !isViewSetup) {
+					View view = getActivity().findViewById(R.id.wbvMain);
+
+					if (view != null) {
+						mainView = view;
+						mainView.setOnTouchListener(onTouchListener);
+						isViewSetup = true;
+					} else {
+						new Handler(Looper.getMainLooper()).postDelayed(this, 100);
+					}
+				}
+			}
+		});
 	}
 
 	private void countTaps(MotionEvent event) {

--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -46,20 +46,28 @@ public class OpenSettingsDialogFragment extends Fragment {
 		setupViewWithRetry();
 	}
 
+	private boolean shouldSetupView() {
+		return getActivity() != null && !isViewSetup;
+	}
+
+	private boolean setupView() {
+		View view = getActivity().findViewById(R.id.wbvMain);
+		if (view != null) {
+			mainView = view;
+			mainView.setOnTouchListener(onTouchListener);
+			isViewSetup = true;
+			return true;
+		}
+
+		return false;
+	}
+
 	private void setupViewWithRetry() {
 		new Handler(Looper.getMainLooper()).post(new Runnable() {
 			@Override
 			public void run() {
-				if (getActivity() != null && !isViewSetup) {
-					View view = getActivity().findViewById(R.id.wbvMain);
-
-					if (view != null) {
-						mainView = view;
-						mainView.setOnTouchListener(onTouchListener);
-						isViewSetup = true;
-					} else {
-						new Handler(Looper.getMainLooper()).postDelayed(this, 100);
-					}
+				if (shouldSetupView() && !setupView()) {
+					new Handler(Looper.getMainLooper()).postDelayed(this, 100);
 				}
 			}
 		});

--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;

--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -41,7 +41,7 @@ public class OpenSettingsDialogFragment extends Fragment {
 	}
 
 	@Override
-	public void onActivityCreated(Bundle savedInstanceState) {
+	public void onActivityCreated(@Nullable Bundle savedInstanceState) {
 		super.onActivityCreated(savedInstanceState);
 		setupViewWithRetry();
 	}

--- a/src/test/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragmentTest.java
+++ b/src/test/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragmentTest.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Looper;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
@@ -59,6 +61,8 @@ public class OpenSettingsDialogFragmentTest {
 		doNothing().when(openSettingsDialogFragment).startActivity(argsStartActivity.capture());
 
 		openSettingsDialogFragment.onCreate(null);
+		openSettingsDialogFragment.onActivityCreated(null);
+		shadowOf(Looper.getMainLooper()).idle();
 	}
 
 	private void tap(OnTouchListener onTouchListener, MotionEvent eventTap, int times) {

--- a/src/test/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragmentTest.java
+++ b/src/test/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragmentTest.java
@@ -1,13 +1,18 @@
 package org.medicmobile.webapp.mobile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -22,190 +27,69 @@ import android.view.View.OnTouchListener;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockSettings;
 import org.mockito.MockedStatic;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.LooperMode;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.stream.IntStream;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(Enclosed.class)
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class OpenSettingsDialogFragmentTest {
+	@RunWith(RobolectricTestRunner.class)
+	public static class BehaviorTest {
+		private OpenSettingsDialogFragment openSettingsDialogFragment;
+		private Activity activity;
+		private ArgumentCaptor<OnTouchListener> argsOnTouch;
+		private ArgumentCaptor<Intent> argsStartActivity;
+		private View view;
 
-	private OpenSettingsDialogFragment openSettingsDialogFragment;
-	private Activity activity;
-	private ArgumentCaptor<OnTouchListener> argsOnTouch;
-	private ArgumentCaptor<Intent> argsStartActivity;
+		@Before
+		public void setup() {
+			activity = mock(Activity.class, RETURNS_SMART_NULLS);
+			doNothing().when(activity).finish();
 
-	@Before
-	public void setup() {
-		activity = mock(Activity.class, RETURNS_SMART_NULLS);
-		doNothing().when(activity).finish();
+			view = mock(View.class);
+			argsOnTouch = ArgumentCaptor.forClass(OnTouchListener.class);
+			doNothing().when(view).setOnTouchListener(argsOnTouch.capture());
 
-		View view = mock(View.class);
-		argsOnTouch = ArgumentCaptor.forClass(OnTouchListener.class);
-		doNothing().when(view).setOnTouchListener(argsOnTouch.capture());
+			MockSettings fragmentSettings = withSettings()
+				.useConstructor()
+				.defaultAnswer(CALLS_REAL_METHODS);
 
-		MockSettings fragmentSettings = withSettings()
-			.useConstructor()
-			.defaultAnswer(CALLS_REAL_METHODS);
+			openSettingsDialogFragment = mock(OpenSettingsDialogFragment.class, fragmentSettings);
+			when(openSettingsDialogFragment.getActivity()).thenReturn(activity);
+			when(openSettingsDialogFragment.getActivity().findViewById(R.id.wbvMain)).thenReturn(view);
+			argsStartActivity = ArgumentCaptor.forClass(Intent.class);
+			doNothing().when(openSettingsDialogFragment).startActivity(argsStartActivity.capture());
 
-		openSettingsDialogFragment = mock(OpenSettingsDialogFragment.class, fragmentSettings);
-		when(openSettingsDialogFragment.getActivity()).thenReturn(activity);
-		when(openSettingsDialogFragment.getActivity().findViewById(R.id.wbvMain)).thenReturn(view);
-		argsStartActivity = ArgumentCaptor.forClass(Intent.class);
-		doNothing().when(openSettingsDialogFragment).startActivity(argsStartActivity.capture());
+			openSettingsDialogFragment.onCreate(null);
+			openSettingsDialogFragment.onActivityCreated(null);
+			shadowOf(Looper.getMainLooper()).idle();
+		}
 
-		openSettingsDialogFragment.onCreate(null);
-		openSettingsDialogFragment.onActivityCreated(null);
-		shadowOf(Looper.getMainLooper()).idle();
-	}
+		private void tap(OnTouchListener onTouchListener, MotionEvent eventTap, int times) {
+			IntStream
+				.range(0, times)
+				.forEach(i -> onTouchListener.onTouch(null, eventTap));
+		}
 
-	private void tap(OnTouchListener onTouchListener, MotionEvent eventTap, int times) {
-		IntStream
-			.range(0, times)
-			.forEach(i -> onTouchListener.onTouch(null, eventTap));
-	}
+		private void positionPointers(OnTouchListener onTouchListener, MotionEvent eventSwipe, float pointer1, float pointer2) {
+			when(eventSwipe.getX(0)).thenReturn(pointer1);
+			when(eventSwipe.getX(1)).thenReturn(pointer2);
+			onTouchListener.onTouch(null, eventSwipe);
+		}
 
-	private void positionPointers(OnTouchListener onTouchListener, MotionEvent eventSwipe, float pointer1, float pointer2) {
-		when(eventSwipe.getX(0)).thenReturn(pointer1);
-		when(eventSwipe.getX(1)).thenReturn(pointer2);
-		onTouchListener.onTouch(null, eventSwipe);
-	}
-
-	@Test
-	public void onTouch_withRightGestures_opensSettingsDialog() {
-		//> GIVEN
-		MotionEvent eventTap = mock(MotionEvent.class);
-		when(eventTap.getPointerCount()).thenReturn(1);
-		when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
-
-		MotionEvent eventSwipe = mock(MotionEvent.class);
-		when(eventSwipe.getPointerCount()).thenReturn(2);
-
-		//> WHEN
-		OnTouchListener onTouchListener = argsOnTouch.getValue();
-		tap(onTouchListener, eventTap, 6);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
-		positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
-		positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
-
-		//> THEN
-		Intent intent = argsStartActivity.getValue();
-		assertEquals(SettingsDialogActivity.class.getName(), intent.getComponent().getClassName());
-		verify(activity).finish();
-	}
-
-	@Test
-	public void onTouch_withNoSwipe_doesNotOpenSettingsDialog() {
-		//> GIVEN
-		MotionEvent eventTap = mock(MotionEvent.class);
-		when(eventTap.getPointerCount()).thenReturn(1);
-		when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
-
-		MotionEvent eventSwipe = mock(MotionEvent.class);
-		when(eventSwipe.getPointerCount()).thenReturn(2);
-
-		//> WHEN
-		OnTouchListener onTouchListener = argsOnTouch.getValue();
-		tap(onTouchListener, eventTap, 6);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
-		positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
-
-		//> THEN
-		verify(openSettingsDialogFragment, never()).startActivity(any());
-		verify(activity, never()).finish();
-	}
-
-	@Test
-	public void onTouch_with1FingerSwipe_doesNotOpenSettingsDialog() {
-		//> GIVEN
-		MotionEvent eventTap = mock(MotionEvent.class);
-		when(eventTap.getPointerCount()).thenReturn(1);
-		when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
-
-		MotionEvent eventSwipe = mock(MotionEvent.class);
-		when(eventSwipe.getPointerCount()).thenReturn(1);
-
-		//> WHEN
-		OnTouchListener onTouchListener = argsOnTouch.getValue();
-		tap(onTouchListener, eventTap, 6);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
-		positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
-		positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
-
-		//> THEN
-		verify(openSettingsDialogFragment, never()).startActivity(any());
-		verify(activity, never()).finish();
-	}
-
-	@Test
-	public void onTouch_withNoEnoughTaps_doesNotOpenSettingsDialog() {
-		//> GIVEN
-		MotionEvent eventTap = mock(MotionEvent.class);
-		when(eventTap.getPointerCount()).thenReturn(1);
-		when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
-
-		MotionEvent eventSwipe = mock(MotionEvent.class);
-		when(eventSwipe.getPointerCount()).thenReturn(2);
-
-		//> WHEN
-		OnTouchListener onTouchListener = argsOnTouch.getValue();
-		tap(onTouchListener, eventTap, 4);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
-		positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
-		positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
-
-		//> THEN
-		verify(openSettingsDialogFragment, never()).startActivity(any());
-		verify(activity, never()).finish();
-	}
-
-	@Test
-	public void onTouch_with2FingerTaps_doesNotOpenSettingsDialog() {
-		//> GIVEN
-		MotionEvent eventTap = mock(MotionEvent.class);
-		when(eventTap.getPointerCount()).thenReturn(2);
-		when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
-
-		MotionEvent eventSwipe = mock(MotionEvent.class);
-		when(eventSwipe.getPointerCount()).thenReturn(2);
-
-		//> WHEN
-		OnTouchListener onTouchListener = argsOnTouch.getValue();
-		tap(onTouchListener, eventTap, 6);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
-		positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
-
-		when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
-		positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
-
-		//> THEN
-		verify(openSettingsDialogFragment, never()).startActivity(any());
-		verify(activity, never()).finish();
-	}
-
-	@Test
-	public void onTouch_withTapTimeout_doesNotOpenSettingsDialog() {
-		Clock startTime = Clock.fixed(Instant.ofEpochMilli(1000), ZoneOffset.UTC);
-		Clock otherTapsTime = Clock.fixed(Instant.ofEpochMilli(1501), ZoneOffset.UTC);
-
-		try (MockedStatic<Clock> mockClock = mockStatic(Clock.class)) {
+		@Test
+		public void onTouch_withRightGestures_opensSettingsDialog() {
 			//> GIVEN
 			MotionEvent eventTap = mock(MotionEvent.class);
 			when(eventTap.getPointerCount()).thenReturn(1);
@@ -214,12 +98,81 @@ public class OpenSettingsDialogFragmentTest {
 			MotionEvent eventSwipe = mock(MotionEvent.class);
 			when(eventSwipe.getPointerCount()).thenReturn(2);
 
-			mockClock.when(Clock::systemUTC).thenReturn(startTime);
+			//> WHEN
+			OnTouchListener onTouchListener = argsOnTouch.getValue();
+			tap(onTouchListener, eventTap, 6);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
+			positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
+			positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
+
+			//> THEN
+			Intent intent = argsStartActivity.getValue();
+			assertEquals(SettingsDialogActivity.class.getName(), intent.getComponent().getClassName());
+			verify(activity).finish();
+		}
+
+		@Test
+		public void onTouch_withNoSwipe_doesNotOpenSettingsDialog() {
+			//> GIVEN
+			MotionEvent eventTap = mock(MotionEvent.class);
+			when(eventTap.getPointerCount()).thenReturn(1);
+			when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
+
+			MotionEvent eventSwipe = mock(MotionEvent.class);
+			when(eventSwipe.getPointerCount()).thenReturn(2);
 
 			//> WHEN
 			OnTouchListener onTouchListener = argsOnTouch.getValue();
-			tap(onTouchListener, eventTap, 2);
-			mockClock.when(Clock::systemUTC).thenReturn(otherTapsTime);
+			tap(onTouchListener, eventTap, 6);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
+			positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
+
+			//> THEN
+			verify(openSettingsDialogFragment, never()).startActivity(any());
+			verify(activity, never()).finish();
+		}
+
+		@Test
+		public void onTouch_with1FingerSwipe_doesNotOpenSettingsDialog() {
+			//> GIVEN
+			MotionEvent eventTap = mock(MotionEvent.class);
+			when(eventTap.getPointerCount()).thenReturn(1);
+			when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
+
+			MotionEvent eventSwipe = mock(MotionEvent.class);
+			when(eventSwipe.getPointerCount()).thenReturn(1);
+
+			//> WHEN
+			OnTouchListener onTouchListener = argsOnTouch.getValue();
+			tap(onTouchListener, eventTap, 6);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
+			positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
+			positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
+
+			//> THEN
+			verify(openSettingsDialogFragment, never()).startActivity(any());
+			verify(activity, never()).finish();
+		}
+
+		@Test
+		public void onTouch_withNoEnoughTaps_doesNotOpenSettingsDialog() {
+			//> GIVEN
+			MotionEvent eventTap = mock(MotionEvent.class);
+			when(eventTap.getPointerCount()).thenReturn(1);
+			when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
+
+			MotionEvent eventSwipe = mock(MotionEvent.class);
+			when(eventSwipe.getPointerCount()).thenReturn(2);
+
+			//> WHEN
+			OnTouchListener onTouchListener = argsOnTouch.getValue();
 			tap(onTouchListener, eventTap, 4);
 
 			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
@@ -231,6 +184,125 @@ public class OpenSettingsDialogFragmentTest {
 			//> THEN
 			verify(openSettingsDialogFragment, never()).startActivity(any());
 			verify(activity, never()).finish();
+		}
+
+		@Test
+		public void onTouch_with2FingerTaps_doesNotOpenSettingsDialog() {
+			//> GIVEN
+			MotionEvent eventTap = mock(MotionEvent.class);
+			when(eventTap.getPointerCount()).thenReturn(2);
+			when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
+
+			MotionEvent eventSwipe = mock(MotionEvent.class);
+			when(eventSwipe.getPointerCount()).thenReturn(2);
+
+			//> WHEN
+			OnTouchListener onTouchListener = argsOnTouch.getValue();
+			tap(onTouchListener, eventTap, 6);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
+			positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
+
+			when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
+			positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
+
+			//> THEN
+			verify(openSettingsDialogFragment, never()).startActivity(any());
+			verify(activity, never()).finish();
+		}
+
+		@Test
+		public void onTouch_withTapTimeout_doesNotOpenSettingsDialog() {
+			Clock startTime = Clock.fixed(Instant.ofEpochMilli(1000), ZoneOffset.UTC);
+			Clock otherTapsTime = Clock.fixed(Instant.ofEpochMilli(1501), ZoneOffset.UTC);
+
+			try (MockedStatic<Clock> mockClock = mockStatic(Clock.class)) {
+				//> GIVEN
+				MotionEvent eventTap = mock(MotionEvent.class);
+				when(eventTap.getPointerCount()).thenReturn(1);
+				when(eventTap.getActionMasked()).thenReturn(MotionEvent.ACTION_DOWN);
+
+				MotionEvent eventSwipe = mock(MotionEvent.class);
+				when(eventSwipe.getPointerCount()).thenReturn(2);
+
+				mockClock.when(Clock::systemUTC).thenReturn(startTime);
+
+				//> WHEN
+				OnTouchListener onTouchListener = argsOnTouch.getValue();
+				tap(onTouchListener, eventTap, 2);
+				mockClock.when(Clock::systemUTC).thenReturn(otherTapsTime);
+				tap(onTouchListener, eventTap, 4);
+
+				when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_POINTER_DOWN);
+				positionPointers(onTouchListener, eventSwipe, (float) 261.81, (float) 264.99);
+
+				when(eventSwipe.getActionMasked()).thenReturn(MotionEvent.ACTION_MOVE);
+				positionPointers(onTouchListener, eventSwipe, (float) 800.90, (float) 850.13);
+
+				//> THEN
+				verify(openSettingsDialogFragment, never()).startActivity(any());
+				verify(activity, never()).finish();
+			}
+		}
+	}
+
+	@RunWith(RobolectricTestRunner.class)
+	@LooperMode(LooperMode.Mode.PAUSED)
+	public static class ViewSetupTest {
+		private OpenSettingsDialogFragment fragment;
+		private Activity mockActivity;
+		private View mockView;
+
+		@Before
+		public void setUp() {
+			fragment = spy(new OpenSettingsDialogFragment());
+			mockActivity = mock(Activity.class);
+			mockView = mock(View.class);
+			doReturn(mockActivity).when(fragment).getActivity();
+		}
+
+		@Test
+		public void SetupViewWithRetry_Success() {
+			when(mockActivity.findViewById(R.id.wbvMain)).thenReturn(mockView);
+
+			fragment.setupViewWithRetry();
+			ShadowLooper.runMainLooperOneTask();
+
+			verify(mockView).setOnTouchListener(any());
+			assertTrue(fragment.isViewSetup);
+		}
+
+		@Test
+		public void testSetupViewWithRetry_NullView_Retries() {
+			when(mockActivity.findViewById(R.id.wbvMain)).thenReturn(null).thenReturn(mockView);
+
+			fragment.setupViewWithRetry();
+			ShadowLooper.runMainLooperOneTask();
+			ShadowLooper.runMainLooperOneTask();
+
+			verify(mockView).setOnTouchListener(any());
+			assertTrue(fragment.isViewSetup);
+		}
+
+		@Test
+		public void testSetupViewWithRetry_NullActivity_DoesNotSetup() {
+			doReturn(null).when(fragment).getActivity();
+
+			fragment.setupViewWithRetry();
+			ShadowLooper.runMainLooperOneTask();
+
+			verify(mockActivity, never()).findViewById(anyInt());
+			assertFalse(fragment.isViewSetup);
+		}
+
+		@Test
+		public void testSetupViewWithRetry_AlreadySetup_DoesNotSetup() {
+			fragment.isViewSetup = true;
+
+			fragment.setupViewWithRetry();
+			ShadowLooper.runMainLooperOneTask();
+
+			verify(mockActivity, never()).findViewById(anyInt());
 		}
 	}
 }


### PR DESCRIPTION
fixes: #376 

The issue seems to be a case when during some events the `OpenSettingsDialogFragment` is not able to find its calling activity which in this case is `EmbeddedBrowserActivity` and since it can't find `EmbeddedBrowserActivity` it's also not able to find the view `wbvMain` which in turn is unable to set the `setOnTouchListener` onto the view because the view is `null`. So, I've added a fallback and retry mechanism to give time for the `EmbeddedBrowserActivity` to load and be "findable" and also retain the instance of `OpenSettingsDialogFragment` because it's just a background listener that listens for taps and swipes.