### PR TITLE
fix(#376): fix issue of OpenSettingsDialogFragment class not being able to find calling Activity by saving the state of the Fragment

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/OpenSettingsDialogFragment.java
@@ -33,6 +33,7 @@ public class OpenSettingsDialogFragment extends Fragment {
 	@Override
 	public void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		setRetainInstance(true);
 		View view = getActivity().findViewById(R.id.wbvMain);
 		view.setOnTouchListener(onTouchListener);
 	}


### PR DESCRIPTION
fixes: #376 

The issue seems to be a case when during some events the OpenSettingsDialogFragment cannot find its calling activity which in this case is EmbeddedBrowserActivity. Since it can't find EmbeddedBrowserActivity it's also not able to find the view wbvMain which in turn is unable to set the setOnTouchListener onto the view because the view is null. So, I've added to retain an instance OpenSettingsDialogFragment when it's called for the first time, and subsequent calls are called from the saved instance which suits our use of the Fragment being a background listener for taps and swipes.