### PR TITLE
fix(#385): Production instance on production app should not have red border

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -19,7 +19,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;

--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -19,6 +19,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -80,13 +81,13 @@ public class EmbeddedBrowserActivity extends Activity {
 
 		this.settings = SettingsStore.in(this);
 		this.appUrl = settings.getAppUrl();
-
+		boolean isProductionApp =  getResources().getBoolean(R.bool.production);
 		this.requestWindowFeature(Window.FEATURE_NO_TITLE);
 		setContentView(R.layout.main);
 
 		// Add an alarming red border if using configurable (i.e. dev)
 		// app with a medic production server.
-		if (settings.allowsConfiguration() && appUrl != null && appUrl.contains("app.medicmobile.org")) {
+		if (settings.allowsConfiguration() && appUrl != null && appUrl.contains("app.medicmobile.org") && !isProductionApp) {
 			View webviewContainer = findViewById(R.id.lytWebView);
 			webviewContainer.setPadding(10, 10, 10, 10);
 			webviewContainer.setBackgroundResource(R.drawable.warning_background);

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <bool name="production">False</bool>
+  <bool name="production">false</bool>
 </resources>

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="production">False</bool>
+</resources>


### PR DESCRIPTION
Fixes #385 by:
- Adding a Boolean resource to indicate if it's a production instance
- Checking the resource to avoid displaying red border