### PR TITLE
chore(#362): bump gradle API to support Android 15 and 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ def getVersionName = {
 }
 
 android {
-  compileSdk 34
+  compileSdk 36
   packagingOptions {
     resources {
       excludes += ['META-INF/LICENSE', 'META-INF/NOTICE']
@@ -114,7 +114,7 @@ android {
 
   defaultConfig {
     //noinspection OldTargetApi
-    targetSdkVersion 34
+    targetSdkVersion 36
     minSdkVersion 21 // Android 5.0
     versionCode getVersionCode()
     versionName getVersionName()


### PR DESCRIPTION
This PR bumps the API to version 36 in an attempt to support Android 15 and 16

closes #362 