### PR TITLE
fix(#426): enlarge CHT server URL input field

### DIFF
--- a/src/main/res/layout/custom_server_form.xml
+++ b/src/main/res/layout/custom_server_form.xml
@@ -13,7 +13,6 @@
     android:id="@+id/txtAppUrl"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_centerVertical="true"
     android:autofillHints=""
     android:hint="@string/txtAppUrl"
     android:inputType="textUri"

--- a/src/main/res/layout/custom_server_form.xml
+++ b/src/main/res/layout/custom_server_form.xml
@@ -11,12 +11,14 @@
 
   <EditText
     android:id="@+id/txtAppUrl"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_centerVertical="true"
     android:autofillHints=""
     android:hint="@string/txtAppUrl"
     android:inputType="textUri"
-    android:padding="32dp" />
+    android:padding="32dp"
+    android:textSize="18sp" />
   <!-- OnClick is ignored because lint generates error
 	     incorrectly.  Test with future build tool versions
 	     to see if this exception can be removed -->


### PR DESCRIPTION
## Summary
- Makes the custom server URL input full-width (`match_parent`) instead of `wrap_content`
- Keeps the URL input at the top of the screen
- Increases text size to `18sp` for improved readability

Closes #426

## Test plan
- [ ] Open unbranded CHT Android app on a tablet and select "Custom"
- [ ] Verify the URL input field spans the full width of the screen
- [ ] Verify the text is readable and large enough
- [ ] Verify the input stays at the top of the screen (not vertically centered)
- [ ] Test on a phone-sized device to ensure it still looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)